### PR TITLE
Feature: Add discovery / Reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 TestResults
 lcov.info
 codecover
+**.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG RUNTIME_IMAGE_TAG=3.1
+
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
 WORKDIR /sources
 
@@ -6,7 +8,7 @@ COPY . ./
 RUN dotnet publish src/Service/Service.csproj -c Release -o dist
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1
+FROM mcr.microsoft.com/dotnet/core/runtime:$RUNTIME_IMAGE_TAG
 WORKDIR /app
 COPY --from=build-env /sources/dist .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+WORKDIR /sources
+
+# Copy solution, restore and build
+COPY . ./
+RUN dotnet publish src/Service/Service.csproj -c Release -o dist
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1
+WORKDIR /app
+COPY --from=build-env /sources/dist .
+
+ENV HASS_HOST localhost
+ENV HASS_PORT 8123
+ENV HASS_TOKEN NOT_SET
+ENV HASS_DAEMONAPPFOLDER /data
+
+RUN mkdir ${HASS_DAEMONAPPFOLDER}
+
+ENTRYPOINT ["dotnet", "Service.dll"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ Please see [https://net-daemon.github.io/netdaemon/](https://net-daemon.github.i
 
 >**The NetDaemon is currently in alpha release so expect things to change.**
 
+## Docker Support
+For those who have Homeassistant running on Docker, not supervised by HASS, the NetDaemon can be shipped as a container and ran in parallel.
+
+To build the image simply execute the build command in the root of the solution
+
+```
+docker build . --tag netdaemon:latest
+```
+
+After the image has been built, you can deploy the container using the following command. It is advised to map the `/data` folder of the container to a local folder as the daemon's apps are linked to this folder.
+
+The following environment variables are available to identify your Home Assistant instance
+* `HASS_HOST`, defaults to *localhost*
+* `HASS_PORT`, default to *8123*
+* `HASS_TOKEN` needs to be set to a valid access token.
+
+Example giving: 
+```
+docker run -v -e HASS_HOST=192.168.1.1 -e HASS_TOKEN=ey123... ~/netdaemon_config:/data --name netdaemon netdaemon
+```
+
 ## Example apps
 
 Please check out the apps being developed for netdaemon. Since documentation is still lacking behind it will be best looking at real code 😊

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Example giving:
 docker run -v -e HASS_HOST=192.168.1.1 -e HASS_TOKEN=ey123... ~/netdaemon_config:/data --name netdaemon netdaemon
 ```
 
+## Companion App (Home Assistant)
+For the full user experiance please download and copy the netdaemon companion component to the `custom_components` folder of your Home Assistant configuration. The companion app registers basic services that are required for the service attributes as well as the dynamic app reload / discovery feature. 
+
+Do not forget to add the component to your Home Assistant configuration file afterwards.
+
+```
+homeassistant:
+  customize: !include customize.yaml
+...
+netdaemon:
+```
+
+Please have a look at 
+
 ## Example apps
 
 Please check out the apps being developed for netdaemon. Since documentation is still lacking behind it will be best looking at real code 😊

--- a/custom_components/netdaemon/__init__.py
+++ b/custom_components/netdaemon/__init__.py
@@ -1,0 +1,24 @@
+DOMAIN = "netdaemon"
+
+ATTR_CLASS = "class"
+ATTR_METHOD = "method"
+
+async def async_setup(hass, config):
+
+    async def handle_register_service(call):
+        daemon_class = call.data.get(ATTR_CLASS, "no class provided")
+        daemon_method = call.data.get(ATTR_METHOD, "no method provided")
+
+        print("Register service {}_{}".format(daemon_class, daemon_method))
+        hass.services.async_register(DOMAIN, "{}_{}".format(daemon_class, daemon_method), netdaemon_noop)
+
+    async def netdaemon_noop(call):
+        # Do nothing for now, the netdaemon subscribes to this service
+        pass
+
+    # Register companion services
+    hass.services.async_register(DOMAIN, "register_service", handle_register_service)
+    hass.services.async_register(DOMAIN, "reload_apps", netdaemon_noop)
+
+    # Return boolean to indicate that initialization was successful.
+    return True

--- a/custom_components/netdaemon/services.yaml
+++ b/custom_components/netdaemon/services.yaml
@@ -1,0 +1,10 @@
+register_service:
+  description: Register a new service for netdaemon, used by the daemon and not to be used by users
+  fields:
+    class:
+      description: The class that implements the service call
+    method:
+      description: The method to call
+reload_daemons:
+  description: Forces the netdamon to reload the apps from the code folder. Only enabled apps are instanciated.
+  

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+
+# Build amd64 image
+docker build . --tag horizon0156/netdaemon:amd64-latest
+
+# Build arm32 image
+docker build . --build-arg RUNTIME_IMAGE_TAG=3.1-buster-slim-arm32v7 --tag horizon0156/netdaemon:arm32-latest
+
+# Push images
+docker push horizon0156/netdaemon:arm32-latest 
+docker push horizon0156/netdaemon:amd64-latest
+
+# Create multi-arch manifest
+docker manifest create \
+    horizon0156/netdaemon:latest \
+    horizon0156/netdaemon:amd64-latest \
+    horizon0156/netdaemon:arm32-latest
+docker manifest push --purge horizon0156/netdaemon:latest

--- a/src/App/NetDaemon.App/Common/INetDaemon.cs
+++ b/src/App/NetDaemon.App/Common/INetDaemon.cs
@@ -35,6 +35,15 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         public string? Id { get; set; }
 
         /// <summary>
+        ///     Gets or sets a flag indicating whether this app is enabled.
+        ///     This property property can be controlled from Home Assistant.
+        /// </summary>
+        /// <remarks>
+        ///     A disabled app will not be initialized during the discovery.
+        /// </remarks>
+        public bool IsEnabled { get; set; }
+
+        /// <summary>
         ///     Saves the app state
         /// </summary>
         /// <remarks>

--- a/src/App/NetDaemon.App/Common/INetDaemon.cs
+++ b/src/App/NetDaemon.App/Common/INetDaemon.cs
@@ -8,7 +8,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
     /// <summary>
     /// Interface that all NetDaemon apps needs to implement
     /// </summary>
-    public interface INetDaemonApp
+    public interface INetDaemonApp : IDisposable
     {
         /// <summary>
         /// Start the application, normally implemented by the base class

--- a/src/App/NetDaemon.App/Common/NetDaemonApp.cs
+++ b/src/App/NetDaemon.App/Common/NetDaemonApp.cs
@@ -13,7 +13,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
     /// <summary>
     ///     Base class för all NetDaemon apps
     /// </summary>
-    public class NetDaemonApp : INetDaemonApp, INetDaemon, IDisposable
+    public class NetDaemonApp : INetDaemonApp, INetDaemon
     {
         private INetDaemon? _daemon;
 

--- a/src/App/NetDaemon.App/Common/NetDaemonApp.cs
+++ b/src/App/NetDaemon.App/Common/NetDaemonApp.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -46,6 +47,9 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
 
         /// <inheritdoc/>
         public string? Id { get; set; }
+
+        /// <inheritdoc/>
+        public bool IsEnabled { get; set; }
 
         /// <inheritdoc/>
         public Task CallService(string domain, string service, dynamic? data = null, bool waitForResponse = false)
@@ -241,6 +245,20 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
                 var expStore = (FluentExpandoObject)Storage;
                 expStore.CopyFrom(obj);
             }
+
+            var appInfo = _daemon!.State
+                                  .Where(s => s.EntityId == $"netdaemon.{Id?.ToLowerInvariant()}")
+                                  .FirstOrDefault();
+
+            var appState = appInfo?.State as string;
+            if (appState == null || (appState != "on" && appState != "off"))
+            {
+                IsEnabled = true;
+                await _daemon.SetState($"netdaemon.{Id?.ToLowerInvariant()}", "on");
+
+                return;
+            }
+            IsEnabled = appState == "on";
         }
 
         /// <inheritdoc/>

--- a/src/Daemon/NetDaemon.Daemon/Daemon/INetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/INetDaemonHost.cs
@@ -1,0 +1,55 @@
+using JoySoftware.HomeAssistant.NetDaemon.Common;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+[assembly: InternalsVisibleTo("NetDaemon.Daemon.Tests")]
+
+namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
+{
+    /// <summary>
+    ///     The interface that interacts with the daemon host main logic
+    /// </summary>
+    public interface INetDaemonHost : INetDaemon
+    {
+        /// <summary>
+        ///     Runs the netdaemon host asynchronous.
+        /// </summary>
+        /// <param name="host"> The Home Assistant instance to which the daemon connected to. </param>
+        /// <param name="port"> The port os the HASS instance. </param>
+        /// <param name="ssl"> Flag indicating whether SSL should be used. </param>
+        /// <param name="token"> User specific access token. </param>
+        /// <param name="cancellationToken"> A cancallation token. </param>
+        /// <returns> The operational task. </returns>
+        Task Run(string host, short port, bool ssl, string token, CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Stops the netdaemon host asynchronous. 
+        /// </summary>
+        /// <returns> The operational task. </returns>
+        Task Stop();
+
+        /// <summary>
+        ///     Stops all the daemon app activities (Schedulers, Service-, State- and Event- subscriptions).
+        /// </summary>
+        /// <returns> The operational task. </returns>
+        Task StopDaemonActivitiesAsync();
+
+        /// <summary>
+        ///     Listens to the given service in the netdaemon domain. Those subscritions 
+        ///     are used internally and are not postponed during reloading service daemons.
+        /// </summary>
+        /// <param name="service"> The name of the service. </param>
+        /// <param name="action"> The async. action that is executed. </param>
+        void ListenCompanionServiceCall(string service, Func<dynamic?, Task> action);
+
+        /// <summary>
+        ///     Sends the status of the netdaemon host to Home Assistant.
+        /// </summary>
+        /// <param name="numberOfLoadedApps"> The number of loaded apps. </param>
+        /// <param name="numberOfRunningApps"> The number of running apps. </param>
+        /// <returns></returns>
+        Task SetDaemonStateAsync(int numberOfLoadedApps, int numberOfRunningApps);
+    }
+}

--- a/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
@@ -15,13 +15,6 @@ using System.Threading.Tasks;
 
 namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
 {
-    internal interface INetDaemonHost : INetDaemon
-    {
-        Task Run(string host, short port, bool ssl, string token, CancellationToken cancellationToken);
-
-        Task Stop();
-    }
-
     public class NetDaemonHost : INetDaemonHost
     {
         /// <summary>
@@ -45,9 +38,11 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
                     new List<(Func<FluentEventProperty, bool>, Func<string, dynamic, Task>)>();
 
         private readonly List<Task> _eventHandlerTasks = new List<Task>();
+
         private readonly IHassClient _hassClient;
 
         private readonly Scheduler _scheduler;
+
         private readonly IDataRepository? _repository;
 
         private readonly IList<(string pattern, Func<string, EntityState?, EntityState?, Task> action)> _stateActions =
@@ -62,6 +57,9 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         private bool _stopped;
 
         private readonly List<(string, string, Func<dynamic?, Task>)> _serviceCallFunctionList
+            = new List<(string, string, Func<dynamic?, Task>)>();
+
+        private readonly List<(string, string, Func<dynamic?, Task>)> _companionServiceCallFunctionList
             = new List<(string, string, Func<dynamic?, Task>)>();
 
         public NetDaemonHost(IHassClient? hassClient, IDataRepository? repository, ILoggerFactory? loggerFactory = null)
@@ -249,7 +247,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
                         {
                             // Remove all completed Tasks
                             _eventHandlerTasks.RemoveAll(x => x.IsCompleted);
-
                             _eventHandlerTasks.Add(HandleNewEvent(changedEvent, cancellationToken));
                         }
                         else
@@ -453,7 +450,9 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
                         throw new NullReferenceException("ServiceData is null! not expected");
                     }
                     var tasks = new List<Task>();
-                    foreach (var (domain, service, func) in _serviceCallFunctionList)
+                    var serviceCallFunctionList = _companionServiceCallFunctionList.Union(_serviceCallFunctionList);
+
+                    foreach (var (domain, service, func) in serviceCallFunctionList)
                     {
                         if (domain == serviceCallData.Domain &&
                             service == serviceCallData.Service)
@@ -594,6 +593,32 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         {
             IEnumerable<string> x = State.Where(func).Select(n => n.EntityId);
             return new InputSelectManager(x, this);
+        }
+
+        /// <inheritdoc/>
+        public async Task StopDaemonActivitiesAsync()
+        {
+            _eventActions.Clear();
+            _eventFunctionList.Clear();
+            _stateActions.Clear();
+            _serviceCallFunctionList.Clear();
+
+            await _scheduler.Stop();
+        }
+
+        /// <inheritdoc/>
+        public void ListenCompanionServiceCall(string service, Func<dynamic?, Task> action)
+            => _companionServiceCallFunctionList.Add(("netdaemon", service.ToLowerInvariant(), action));
+
+        /// <inheritdoc/>
+        public async Task SetDaemonStateAsync(int numberOfLoadedApps, int numberOfRunningApps)
+        {
+            await SetState(
+                "netdaemon.status",
+                "Connected", // State will alawys be connected, otherwise state could not be set.
+                ("number_of_loaded_daemons", numberOfLoadedApps),
+                ("number_of_running_daemons", numberOfRunningApps),
+                ("version", GetType().Assembly.GetName().Version?.ToString() ?? "N/A"));
         }
     }
 }

--- a/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
@@ -616,8 +616,8 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
             await SetState(
                 "netdaemon.status",
                 "Connected", // State will alawys be connected, otherwise state could not be set.
-                ("number_of_loaded_daemons", numberOfLoadedApps),
-                ("number_of_running_daemons", numberOfRunningApps),
+                ("number_of_loaded_apps", numberOfLoadedApps),
+                ("number_of_running_apps", numberOfRunningApps),
                 ("version", GetType().Assembly.GetName().Version?.ToString() ?? "N/A"));
         }
     }

--- a/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
@@ -232,9 +232,17 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App
 
                 foreach (var appInstance in yamlAppConfig.Instances)
                 {
-                    result.Add(appInstance);
                     await appInstance.StartUpAsync(host!).ConfigureAwait(false);
                     await appInstance.RestoreAppStateAsync().ConfigureAwait(false);
+
+                    if (!appInstance.IsEnabled)
+                    {
+                        appInstance.Dispose();
+                        host!.Logger.LogInformation($"Skipped disabled app {appInstance.GetType().Name}");
+                        continue;
+                    }
+
+                    result.Add(appInstance);
                     await appInstance.InitializeAsync().ConfigureAwait(false);
                     appInstance.HandleAttributeInitialization(host!);
                     host!.Logger.LogInformation($"Successfully loaded app {appInstance.GetType().Name}");

--- a/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
@@ -197,7 +197,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App
 
         public async Task EnableApplicationDiscoveryServiceAsync(INetDaemonHost host, bool discoverServicesOnStartup)
         {
-            host.ListenCompanionServiceCall("reload_daemons", async (_) => await ReloadApplicationsAsync(host));
+            host.ListenCompanionServiceCall("reload_apps", async (_) => await ReloadApplicationsAsync(host));
 
             if (discoverServicesOnStartup)
             {

--- a/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/App/CodeManager.cs
@@ -183,6 +183,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App
             _yamlConfig = new YamlConfig(codeFolder);
 
             LoadLocalAssemblyApplicationsForDevelopment();
+            CompileScriptsInCodeFolder();
         }
 
         public void Dispose()
@@ -201,7 +202,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App
 
             if (discoverServicesOnStartup)
             {
-                CompileScriptsInCodeFolder();
                 await InstanceAndInitApplications(host);
             }
         }
@@ -224,6 +224,8 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App
         public async Task<IEnumerable<INetDaemonApp>> InstanceAndInitApplications(INetDaemonHost? host)
         {
             _ = (host as INetDaemonHost) ?? throw new ArgumentNullException(nameof(host));
+
+            CompileScriptsInCodeFolder();
 
             var result = new List<INetDaemonApp>();
             foreach (string file in _yamlConfig.GetAllConfigFilePaths())

--- a/src/DaemonRunner/DaemonRunner/Service/RunnerService.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/RunnerService.cs
@@ -6,7 +6,9 @@ using JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -77,19 +79,20 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service
                         {
                             if (_daemonHost.Connected)
                             {
-                                try
+                                using (var codeManager = new CodeManager(sourceFolder))
                                 {
-                                    // Instance all apps
-                                    var codeManager = new CodeManager(sourceFolder);
-                                    await codeManager.InstanceAndInitApplications((INetDaemon)_daemonHost).ConfigureAwait(false);
-                                }
-                                catch (Exception e)
-                                {
-                                    _logger.LogError(e, "Failed to load applications");
-                                }
+                                    try
+                                    {
+                                        await codeManager.EnableApplicationDiscoveryServiceAsync(_daemonHost, discoverServicesOnStartup: true);
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        _logger.LogError(e, "Failed to load applications");
+                                    }
 
-                                // Wait until daemon stops
-                                await daemonHostTask.ConfigureAwait(false);
+                                    // Wait until daemon stops
+                                    await daemonHostTask.ConfigureAwait(false);
+                                }
                             }
                             else
                             {

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
@@ -1,4 +1,5 @@
 using JoySoftware.HomeAssistant.NetDaemon.Common;
+using JoySoftware.HomeAssistant.NetDaemon.Daemon;
 using JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.App;
 using JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.Config;
 using Moq;
@@ -171,7 +172,7 @@ app:
         {
             // ARRANGE
             var path = Path.Combine(ConfigFixturePath, "level2");
-            var moqDaemon = new Mock<INetDaemon>();
+            var moqDaemon = new Mock<INetDaemonHost>();
             var moqLogger = new LoggerMock();
 
             moqDaemon.SetupGet(n => n.Logger).Returns(moqLogger.Logger);
@@ -186,7 +187,7 @@ app:
         {
             // ARRANGE
             var path = Path.Combine(ConfigFixturePath, "mulitinstance");
-            var moqDaemon = new Mock<INetDaemon>();
+            var moqDaemon = new Mock<INetDaemonHost>();
             var moqLogger = new LoggerMock();
 
             moqDaemon.SetupGet(n => n.Logger).Returns(moqLogger.Logger);


### PR DESCRIPTION
Hey, hope you're doing well :)

Next one and this time to `dev`. As already mentioned, I've implemented a first version of a reload / discover service. Basically I've connected a service that triggers a reload of all applications and disposes existing daemons. I was thinking about a File watcher first, but as user specific apps might write files to the local folder, this would cause unnecessary reloads. Using this approach the changes are not that complex and the functionality is more convenient than restarting the whole daemon. 

In addition, I've added a new IsEnabled flag that recovers from the corresponding Home Assistant. There it is now possible to enable / disable apps without moving them in the `apps` folder. This is heavily used in my production setup when I temporary need to disable motion sensor triggered automations in case of a full house ;)

The DaemonHost is also writing his state to HA's state machine, so you can easily review the number of loaded / instantiated apps. 

Let me know what you think and feel free to include this to your branch as well. 

I've also published a set of my applications that I've written in the last days in case you want to extend your example list. There are also extensions that deals with Homematic devices and keypress events.

https://github.com/Horizon0156/netdaemon-apps/tree/master/apps 

e.g.
```
HomematicSwitchEvent("000858A99D84DE")
                .Channel1()
                .PressedShort()
                .UseEntities("light.kuche")
                .TurnOn()
                .WithAttribute("brightness", 127)
                .Execute();
```

Thanks again for the great work on this daemon. It's running for a week now in our house without any delays or issues.

Have a good one.  

![Preview](https://i.imgur.com/RxJ2l9r.png)