### PR TITLE
Feature: DelayUntilStateChange

### DIFF
--- a/src/App/NetDaemon.App/Common/NetDaemonApp.cs
+++ b/src/App/NetDaemon.App/Common/NetDaemonApp.cs
@@ -120,7 +120,11 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
                 _daemon?.ListenServiceCall(domain, service, action);
 
         /// <inheritdoc/>
-        public void ListenState(string pattern, Func<string, EntityState?, EntityState?, Task> action) => _daemon?.ListenState(pattern, action);
+        public string? ListenState(string pattern, Func<string, EntityState?, EntityState?, Task> action) => _daemon?.ListenState(pattern, action);
+
+        /// <inheritdoc/>
+        public void CancelListenState(string id) => _daemon?.CancelListenState(id);
+
 
         /// <inheritdoc/>
         public async ValueTask<T> GetDataAsync<T>(string id)
@@ -308,6 +312,8 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
             Dispose(true);
         }
 
+        #endregion IDisposable Support
+
         /// <inheritdoc/>
         public IFluentInputSelect InputSelect(params string[] inputSelectParams)
         {
@@ -329,6 +335,25 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
             return _daemon!.InputSelects(func);
         }
 
-        #endregion IDisposable Support
+        /// <inheritdoc/>
+        public IDelayResult DelayUntilStateChange(IEnumerable<string> entityIds, object? to = null, object? from = null, bool allChanges = false)
+        {
+            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            return _daemon!.DelayUntilStateChange(entityIds, to, from, allChanges);
+        }
+
+        /// <inheritdoc/>
+        public IDelayResult DelayUntilStateChange(string entityId, object? to = null, object? from = null, bool allChanges = false)
+        {
+            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            return _daemon!.DelayUntilStateChange(entityId, to, from, allChanges);
+        }
+
+        /// <inheritdoc/>
+        public IDelayResult DelayUntilStateChange(IEnumerable<string> entityIds, Func<EntityState?, EntityState?, bool> stateFunc)
+        {
+            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            return _daemon!.DelayUntilStateChange(entityIds, stateFunc);
+        }
     }
 }


### PR DESCRIPTION
The API both fluent and normal API gets the possibility to wait for a state change. This required also to support cancelation of listen events. This means that you now also can cancel any WhenStateChange or ListenEvent calls in your own apps.

(this PR will be merged when Fluent API is done)

code example of normal API 

```csharp

await DelayUntilStateChange("input_boolean.checkitout", to: "on").Task;

```
The returned type is a object where you use it to wait and use own time out. When that return object is disposed it will cancel the task but you can also cancel yourself.

```csharp

using var stateChangeDelay = DelayUntilStateChange("input_boolean.checkitout", to: "on").Task;
var resultTask = await Task.WhenAny(stateChangeDelay.Task, new CancellationTokenSource(TimeSpan.FromHours(1)).Token.AsTask());
if (resultTask.IsCanceled)
{
      // Ops the state did not change within the hour
}
else
{
     // Yay the state changed
}

```

Fluent API example

```csharp

await Entity("binary_sensor.pir")
    .DelayUntilStateChange((to, _) => to?.State == "on").Task;

```