### PR TITLE
Release builds, adding support to make releases to docker for addon using github actions

### DIFF
--- a/.github/workflows/tags_nuget.yml
+++ b/.github/workflows/tags_nuget.yml
@@ -1,0 +1,38 @@
+#### Build and tests all pushes, also code coverage
+name: publish nuget packages to nuget server
+on:
+    push:
+        tags:
+        - '*'
+jobs:
+    deploy_nuget:
+        name: publish nuget packages
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - uses: actions/setup-dotnet@v1
+            - name: Get Git Version
+              uses: docker://gittools/gitversion:5.2.5-beta1-7-linux-netcoreapp2.1
+              with:
+                args: /github/workspace /nofetch /exec /bin/sh /execargs "-c \"echo $GitVersion_FullSemVer > /github/workspace/version.txt\""
+            - name: publish on version change
+              uses: rohith/publish-nuget@v2
+              with:
+                PROJECT_FILE_PATH: src/DaemonRunner/DaemonRunner/DaemonRunner.csproj # Relative to repository root
+                VERSION_STATIC: ${GIT_TAG_NAME}-alpha
+                # VERSION_FILE_PATH: Directory.Build.props # Filepath with version info, relative to repository root. Defaults to project file
+                # VERSION_REGEX: <Version>(.*)<\/Version> # Regex pattern to extract version info in a capturing group
+                # TAG_COMMIT: true # Flag to enable / disalge git tagging
+                # TAG_FORMAT: v* # Format of the git tag, [*] gets replaced with version
+                # NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key
+                # PACKAGE_NAME: NuGet package name, required when it's different from project name. Defaults to project name
+            # - name: Build code
+            #   run: dotnet build
+            # - name: Test code
+            #   run: dotnet test -v minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{github.workspace}}/codecover/lcov.info
+
+            # - name: Publish coverage report to coveralls.io
+            #   uses: coverallsapp/github-action@master
+            #   with:
+            #     github-token: ${{ secrets.GITHUB_TOKEN }}
+            #     path-to-lcov: ${{github.workspace}}/codecover/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NetDaemon - Application daemon in .NET core for Home Assistant
 
-[![Build Status](https://dev.azure.com/helto4real0721/NetDaemon/_apis/build/status/NetDaemon%20CI%20pipeline?branchName=master)](https://dev.azure.com/helto4real0721/NetDaemon/_build/latest?definitionId=3&branchName=master)
+![CI build](https://github.com/net-daemon/netdaemon/workflows/CI%20build/badge.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/net-daemon/netdaemon/badge.svg?branch=fix_test_build)](https://coveralls.io/github/net-daemon/netdaemon?branch=fix_test_build)
 
 <a href="https://www.buymeacoffee.com/ij1qXRM6E" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>
 

--- a/tests/NetDaemon.Daemon.Tests/FluentTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/FluentTests.cs
@@ -38,7 +38,7 @@ namespace NetDaemon.Daemon.Tests
             DefaultDaemonHost
                 .Entity("binary_sensor.pir")
                 .WhenStateChange("off")
-                .AndNotChangeFor(TimeSpan.FromMilliseconds(20))
+                .AndNotChangeFor(TimeSpan.FromMilliseconds(100))
                 .UseEntity("light.correct_entity")
                 .TurnOff()
                 .Execute();
@@ -47,7 +47,7 @@ namespace NetDaemon.Daemon.Tests
             // ASSERT
             await Task.Delay(10); // After 10ms we should not have call
             DefaultHassClientMock.VerifyCallServiceTimes("turn_off", Times.Never());
-            await Task.Delay(50); // After 30ms we should have call
+            await Task.Delay(500); // After 30ms we should have call
 
             DefaultHassClientMock.VerifyCallServiceTimes("turn_off", Times.Once());
 


### PR DESCRIPTION
This PR will support
- Push netdaemon / homeassistant-addon-[arch]:dev every build of dev branch
- Push netdaemon / homeassistant-addon-[arch]:latest on making a release tag