### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,6 +8,8 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - uses: actions/setup-dotnet@v1
+              with:
+                dotnet-version: '3.1.200' # SDK Version
             - name: Build code
               run: dotnet build
             - name: Test code

--- a/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
@@ -252,7 +252,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             // Called once after 150 ms
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Once);
 
-            await Task.Delay(600);
+            await Task.Delay(1000);
 
             // Called twice
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Exactly(2));

--- a/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
@@ -232,7 +232,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
 
             // Add the player that we want to fake having with the fake playing 0.1 second media duration
             dynamic currentStateAttributes = new ExpandoObject();
-            currentStateAttributes.media_duration = 0.1;
+            currentStateAttributes.media_duration = 0.6;
 
             DefaultDaemonHost.InternalState["media_player.fakeplayer"] = new EntityState
             {
@@ -240,11 +240,11 @@ namespace NetDaemon.Daemon.Tests.Daemon
                 Attribute = currentStateAttributes
             };
 
-            await Task.Delay(100);
+            // await Task.Delay(100);
 
             // ACT
             DefaultDaemonHost.Speak("media_player.fakeplayer", "Hello test!");
-            await Task.Delay(80);
+            await Task.Delay(100);
             DefaultDaemonHost.Speak("media_player.fakeplayer", "Hello test!");
 
             // ASSERT
@@ -252,7 +252,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             // Called once after 150 ms
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Once);
 
-            await Task.Delay(300);
+            await Task.Delay(600);
 
             // Called twice
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Exactly(2));

--- a/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
@@ -232,7 +232,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
 
             // Add the player that we want to fake having with the fake playing 0.1 second media duration
             dynamic currentStateAttributes = new ExpandoObject();
-            currentStateAttributes.media_duration = 0.6;
+            currentStateAttributes.media_duration = 0.1;
 
             DefaultDaemonHost.InternalState["media_player.fakeplayer"] = new EntityState
             {
@@ -244,16 +244,15 @@ namespace NetDaemon.Daemon.Tests.Daemon
 
             // ACT
             DefaultDaemonHost.Speak("media_player.fakeplayer", "Hello test!");
-            await Task.Delay(100);
             DefaultDaemonHost.Speak("media_player.fakeplayer", "Hello test!");
 
             // ASSERT
 
-            // Called once after 150 ms
+            await Task.Delay(50);
+
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Once);
 
-            await Task.Delay(1000);
-
+            await Task.Delay(100);
             // Called twice
             DefaultHassClientMock.Verify(n => n.CallService("tts", "google_cloud_say", expectedAttributesExpObject, true), Times.Exactly(2));
 


### PR DESCRIPTION
Timing on tests is different in different build environments. This is why I have to adjust the timings and add time to tests cause build env not as fast as dev comtputer. Probably need to refactor these tests in the future.