### PR TITLE
Fixed an issue where the sceduler stops accepting new schedules after restart.

### DIFF
--- a/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
@@ -611,7 +611,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
             _stateActions.Clear();
             _serviceCallFunctionList.Clear();
 
-            await _scheduler.Stop();
+            await _scheduler.Restart();
         }
 
         /// <inheritdoc/>

--- a/src/Daemon/NetDaemon.Daemon/Daemon/Scheduler.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/Scheduler.cs
@@ -28,7 +28,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         /// <summary>
         ///     Used to cancel all running tasks
         /// </summary>
-        private readonly CancellationTokenSource _cancelSource = new CancellationTokenSource();
+        private CancellationTokenSource _cancelSource = new CancellationTokenSource();
 
         private readonly ConcurrentDictionary<int, Task> _scheduledTasks
                     = new ConcurrentDictionary<int, Task>();
@@ -269,6 +269,16 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
             if (_scheduledTasks.Values.Count(n => n.IsCompleted == false) > 0)
                 // Todo: Some kind of logging have to be done here to tell user which task caused timeout
                 throw new ApplicationException("Failed to cancel all tasks");
+        }
+
+        /// <summary>
+        ///     Restarts the scheduler. 
+        ///     Existing schedules are cancelled and the scheduler remains usable.
+        /// </summary>
+        public async Task Restart()
+        {
+            await Stop();
+            _cancelSource = new CancellationTokenSource();
         }
 
         private async Task SchedulerLoop()


### PR DESCRIPTION
Last one for today. I figured out that the scheduler stops accepting new schedules after discovery was triggered. I'm now resetting the `CancellationToken` which solves the issue. 

```
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Hello World
trce: JoySoftware.HomeAssistant.NetDaemon.Daemon.Scheduler[0]
      RunDaily, Time: 3/24/2020 9:06:27 PM, parsed time: 3/24/2020 10:00:00 PM,  Delay 00:53:32.1613160
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Successfully loaded app HelloWorld
--> Triggered restart
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Hello World's supposed to be disposed
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Hello World
trce: JoySoftware.HomeAssistant.NetDaemon.Daemon.Scheduler[0]
      RunDaily, Time: 3/24/2020 9:06:37 PM, parsed time: 3/24/2020 10:00:00 PM,  Delay 00:53:22.3838310
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Successfully loaded app HelloWorld
info: JoySoftware.HomeAssistant.NetDaemon.Daemon.NetDaemonHost[0]
      Hello World's supposed to be finalized
```