### PR TITLE
Remove redundant APIs

### DIFF
--- a/src/App/NetDaemon.App/Common/ExtensionMethods.cs
+++ b/src/App/NetDaemon.App/Common/ExtensionMethods.cs
@@ -1,0 +1,28 @@
+
+using System.Collections.Generic;
+
+namespace JoySoftware.HomeAssistant.NetDaemon.Common
+{
+    /// <summary>
+    ///     Useful extension methods used
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        ///     Converts a valuepair to dynamic object
+        /// </summary>
+        /// <param name="attributeNameValuePair"></param>
+        public static dynamic ToDynamic(this (string name, object val)[] attributeNameValuePair)
+        {
+            // Convert the tuple name/value pair to tuple that can be serialized dynamically
+            var attributes = new FluentExpandoObject(true, true);
+            foreach (var (attribute, value) in attributeNameValuePair)
+            {
+                ((IDictionary<string, object>)attributes).Add(attribute, value);
+            }
+
+            dynamic result = attributes;
+            return result;
+        }
+    }
+}

--- a/src/App/NetDaemon.App/Common/INetDaemon.cs
+++ b/src/App/NetDaemon.App/Common/INetDaemon.cs
@@ -167,12 +167,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
             Func<dynamic?, Task> action);
 
         /// <summary>
-        ///     Turn on entity who support the service call
-        /// </summary>
-        /// <param name="entityId">The unique id of the entity</param>
-        /// <param name="attributes">Name/Value pair of the attribute</param>
-
-        /// <summary>
         ///     Set entity state
         /// </summary>
         /// <param name="entityId">The unique id of the entity</param>

--- a/src/App/NetDaemon.App/Common/INetDaemon.cs
+++ b/src/App/NetDaemon.App/Common/INetDaemon.cs
@@ -172,22 +172,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <param name="entityId">The unique id of the entity</param>
         /// <param name="attributes">Name/Value pair of the attribute</param>
 
-        Task TurnOnAsync(string entityId, params (string name, object val)[] attributes);
-
-        /// <summary>
-        ///     Turn off entity who support the service call
-        /// </summary>
-        /// <param name="entityId">The unique id of the entity</param>
-        /// <param name="attributes">Name/Value pair of the attribute</param>
-        Task TurnOffAsync(string entityId, params (string name, object val)[] attributes);
-
-        /// <summary>
-        ///     Toggle entity who support the service call
-        /// </summary>
-        /// <param name="entityId">The unique id of the entity</param>
-        /// <param name="attributes">Name/Value pair of the attribute</param>
-        Task ToggleAsync(string entityId, params (string name, object val)[] attributes);
-
         /// <summary>
         ///     Set entity state
         /// </summary>
@@ -272,12 +256,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// </summary>
         /// <param name="func">The lambda expression selecting input select</param>
         IFluentInputSelect InputSelects(Func<IEntityProperties, bool> func);
-
-        /// <summary>
-        ///     Selects one or more light entities to do action on
-        /// </summary>
-        /// <param name="entityId">The unique id of the entity</param>
-        ILight Light(params string[] entityId);
 
         /// <summary>
         ///     Selects one or more media player entities to do action on

--- a/src/App/NetDaemon.App/Common/NetDaemonApp.cs
+++ b/src/App/NetDaemon.App/Common/NetDaemonApp.cs
@@ -102,13 +102,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         }
 
         /// <inheritdoc/>
-        public ILight Light(params string[] entity)
-        {
-            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
-            return _daemon!.Light(entity);
-        }
-
-        /// <inheritdoc/>
         public void ListenEvent(string ev, Func<string, dynamic?, Task> action) => _daemon?.ListenEvent(ev, action);
 
         /// <inheritdoc/>
@@ -263,27 +256,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
                 return;
             }
             IsEnabled = appState == "on";
-        }
-
-        /// <inheritdoc/>
-        public Task ToggleAsync(string entityId, params (string name, object val)[] attributes)
-        {
-            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
-            return _daemon!.ToggleAsync(entityId, attributes);
-        }
-
-        /// <inheritdoc/>
-        public Task TurnOffAsync(string entityId, params (string name, object val)[] attributes)
-        {
-            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
-            return _daemon!.TurnOffAsync(entityId, attributes);
-        }
-
-        /// <inheritdoc/>
-        public Task TurnOnAsync(string entityId, params (string name, object val)[] attributes)
-        {
-            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
-            return _daemon!.TurnOnAsync(entityId, attributes);
         }
 
         #region IDisposable Support

--- a/src/CustomApp/MyApp.cs
+++ b/src/CustomApp/MyApp.cs
@@ -26,8 +26,6 @@ namespace app
             Log("Tomas light changed!");
             Log($"New state = {newState.State}");
 
-            await TurnOnAsync("light.vardagsrummet",
-                ("brightness", "100"), ("color_temp", 123));
 
             //await And("light.vardagsrummet")
             //    .TurnOn(

--- a/src/Daemon/NetDaemon.Daemon/Daemon/ExtensionMethods.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/ExtensionMethods.cs
@@ -136,17 +136,17 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
             return state;
         }
 
-        public static dynamic ToDynamic(this (string name, object val)[] attributeNameValuePair)
-        {
-            // Convert the tuple name/value pair to tuple that can be serialized dynamically
-            var attributes = new FluentExpandoObject(true, true);
-            foreach (var (attribute, value) in attributeNameValuePair)
-            {
-                ((IDictionary<string, object>)attributes).Add(attribute, value);
-            }
+        // public static dynamic ToDynamic(this (string name, object val)[] attributeNameValuePair)
+        // {
+        //     // Convert the tuple name/value pair to tuple that can be serialized dynamically
+        //     var attributes = new FluentExpandoObject(true, true);
+        //     foreach (var (attribute, value) in attributeNameValuePair)
+        //     {
+        //         ((IDictionary<string, object>)attributes).Add(attribute, value);
+        //     }
 
-            dynamic result = attributes;
-            return result;
-        }
+        //     dynamic result = attributes;
+        //     return result;
+        // }
     }
 }

--- a/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
@@ -355,64 +355,6 @@ namespace NetDaemon.Daemon.Tests.Daemon
         }
 
         [Fact]
-        public async Task ToggleAsyncWithLightCallsSendMessageWithCorrectEntityId()
-        {
-            // ARRANGE
-            var excpectedAttributes = new ExpandoObject();
-            ((IDictionary<string, object>)excpectedAttributes)["entity_id"] = "light.correct_entity";
-
-            // ACT
-            await DefaultDaemonHost.ToggleAsync("light.correct_entity");
-
-            // ASSERT
-
-            DefaultHassClientMock.Verify(n => n.CallService("light", "toggle", excpectedAttributes, It.IsAny<bool>()));
-        }
-
-        [Fact]
-        public async Task TurnOffAsyncWithLightCallsSendMessageWithCorrectEntityId()
-        {
-            // ARRANGE
-            var (_, expectedAttributes) = GetDynamicObject(
-              ("entity_id", "light.correct_entity")
-            );
-
-            // ACT
-            await DefaultDaemonHost.TurnOffAsync("light.correct_entity");
-
-            // ASSERT
-
-            DefaultHassClientMock.Verify(n => n.CallService("light", "turn_off", expectedAttributes, It.IsAny<bool>()));
-        }
-
-        [Fact]
-        public async Task TurnOnAsyncWithErrorEntityIdThrowsApplicationException()
-        {
-            // ARRANGE
-
-            // ACT
-            var ex = await Assert.ThrowsAsync<ApplicationException>(async () => await DefaultDaemonHost.TurnOnAsync("light!correct_entity"));
-
-            Assert.Equal("entity_id is mal formatted light!correct_entity", ex.Message);
-        }
-
-        [Fact]
-        public async Task TurnOnAsyncWithLightCallsSendMessageWithCorrectEntityId()
-        {
-            // ARRANGE
-            var (_, expectedAttributes) = GetDynamicObject(
-              ("entity_id", "light.correct_entity")
-            );
-
-            // ACT
-            await DefaultDaemonHost.TurnOnAsync("light.correct_entity");
-
-            // ASSERT
-
-            DefaultHassClientMock.Verify(n => n.CallService("light", "turn_on", expectedAttributes, It.IsAny<bool>()));
-        }
-
-        [Fact]
         public async Task CallServiceEventShouldCallCorrectFunction()
         {
             // ARRANGE

--- a/tests/NetDaemon.Daemon.Tests/FluentTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/FluentTests.cs
@@ -544,40 +544,6 @@ namespace NetDaemon.Daemon.Tests
         }
 
         [Fact]
-        public async Task TurnOffLightLambdaAttributeSelectionCallsCorrectServiceCall()
-        {
-            // ARRANGE
-            var cancelSource = DefaultHassClientMock.GetSourceWithTimeout();
-            await DefaultDaemonHost.Run("host", 8123, false, "token", cancelSource.Token);
-
-            // ACT
-            await DefaultDaemonHost
-                .Lights(n => n?.Attribute?.test >= 100)
-                .TurnOff()
-                .ExecuteAsync();
-
-            // ASSERT
-            DefaultHassClientMock.VerifyCallServiceTimes("turn_off", Times.Exactly(2));
-            DefaultHassClientMock.VerifyCallService("light", "turn_off", ("entity_id", "light.correct_entity"));
-            DefaultHassClientMock.VerifyCallService("light", "turn_off", ("entity_id", "light.correct_entity2"));
-        }
-
-        [Fact]
-        public async Task TurnOffLightWithoutDomainCallsCorrectServiceCall()
-        {
-            // ARRANGE
-            // ACT
-            await DefaultDaemonHost
-                .Light("correct_entity")
-                .TurnOff()
-                .ExecuteAsync();
-
-            // ASSERT
-            DefaultHassClientMock.VerifyCallServiceTimes("turn_off", Times.Once());
-            DefaultHassClientMock.VerifyCallService("light", "turn_off", ("entity_id", "light.correct_entity"));
-        }
-
-        [Fact]
         public async Task TurnOffMultipleEntityCallsCorrectServiceCall()
         {
             // ARRANGE

--- a/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
@@ -66,9 +66,10 @@ namespace NetDaemon.Daemon.Tests
             await using (IScheduler scheduler = new Scheduler(null, loggerMock.LoggerFactory))
             {
                 // ACT
-                scheduledResult = scheduler.RunIn(20, async () =>
+                scheduledResult = scheduler.RunIn(20, () =>
                 {
                     int i = int.Parse("Not an integer makes runtime error!");
+                    return Task.CompletedTask;
                 });
 
                 await Task.Delay(100);
@@ -216,9 +217,10 @@ namespace NetDaemon.Daemon.Tests
             await using (IScheduler scheduler = new Scheduler(mockTimeManager.Object, loggerMock.LoggerFactory))
             {
                 // ACT
-                scheduledResult = scheduler.RunDaily("10:00:01", async () =>
+                scheduledResult = scheduler.RunDaily("10:00:01", () =>
                {
                    int i = int.Parse("Not an integer makes runtime error!");
+                   return Task.CompletedTask;
                });
                 await Task.Delay(1000);
             }
@@ -248,9 +250,10 @@ namespace NetDaemon.Daemon.Tests
             await using (IScheduler scheduler = new Scheduler(mockTimeManager.Object, loggerMock.LoggerFactory))
             {
                 // ACT
-                scheduledResult = scheduler.RunDaily("10:00:01", new DayOfWeek[] { DayOfWeek.Saturday }, async () =>
+                scheduledResult = scheduler.RunDaily("10:00:01", new DayOfWeek[] { DayOfWeek.Saturday }, () =>
                  {
                      int i = int.Parse("Not an integer makes runtime error!");
+                     return Task.CompletedTask;
                  });
                 await Task.Delay(1000);
             }
@@ -436,9 +439,10 @@ namespace NetDaemon.Daemon.Tests
             await using (IScheduler scheduler = new Scheduler(mockTimeManager.Object, loggerMock.LoggerFactory))
             {
                 // ACT
-                scheduledResult = scheduler.RunEveryMinute(0, async () =>
+                scheduledResult = scheduler.RunEveryMinute(0, () =>
                 {
                     int i = int.Parse("Not an integer makes runtime error!");
+                    return Task.CompletedTask;
                 });
                 await Task.Delay(1000);
 


### PR DESCRIPTION
As we move towards a more stable API:s I want to clean up some redundant API:s. I rather add more if the community wants it. After this PR the APIs will be more stable but not guaranteed not to be changed until first release. 

**BREAKING CHANGE!!**
Following API calls are removed.

- TurnOnAsync
- TurnOffAsync
- ToggleAsync
- Light / Lights

There are alternatives. Use `await Entity("light.some_light").TurnOn().ExecuteAsync();` or `CallService`instead.

If you still want to use these please copy the extensions methods I provided in my repo:
https://github.com/helto4real/hassio/blob/master/netdaemon/apps/Extensions/ServiceExtensions.cs