### PR TITLE
GetApp and app dependencies support

### DIFF
--- a/src/App/NetDaemon.App/Common/INetDaemon.cs
+++ b/src/App/NetDaemon.App/Common/INetDaemon.cs
@@ -25,7 +25,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
     /// <summary>
     /// Interface that all NetDaemon apps needs to implement
     /// </summary>
-    public interface INetDaemonApp : IDisposable
+    public interface INetDaemonApp : IDisposable, IEquatable<INetDaemonApp>
     {
         /// <summary>
         /// Start the application, normally implemented by the base class
@@ -82,6 +82,11 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         ///     It is implemented async so state will be lazy saved
         /// </remarks>
         Task RestoreAppStateAsync();
+
+        /// <summary>
+        ///     The dependencies that needs to be initialized before this app
+        /// </summary>
+        IEnumerable<string> Dependencies { get; set; }
     }
 
     /// <summary>
@@ -196,6 +201,12 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         /// <param name="entityId">The unique id of the entity</param>
         /// <returns></returns>
         EntityState? GetState(string entityId);
+
+        /// <summary>
+        ///     Get application instance by application instance id
+        /// </summary>
+        /// <param name="appInstanceId">The identity of the app instance</param>
+        NetDaemonApp? GetApp(string appInstanceId);
 
         /// <summary>
         ///     Selects one or more entities to do action on

--- a/src/App/NetDaemon.App/Common/NetDaemonApp.cs
+++ b/src/App/NetDaemon.App/Common/NetDaemonApp.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -30,6 +31,11 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
 
         private FluentExpandoObject? _storageObject;
         internal FluentExpandoObject? InternalStorageObject { get { return _storageObject; } set { _storageObject = value; } }
+
+        /// <summary>
+        ///    Dependencies on other applications that will be initialized before this app
+        /// </summary>
+        public IEnumerable<string> Dependencies { get; set; } = new List<string>();
 
         /// <inheritdoc/>
         public ILogger? Logger { get; set; }
@@ -134,6 +140,13 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         }
 
         /// <inheritdoc/>
+        public NetDaemonApp? GetApp(string appInstanceId)
+        {
+            _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            return _daemon!.GetApp(appInstanceId);
+        }
+
+        /// <inheritdoc/>
         public void Log(string message, LogLevel level = LogLevel.Information) => Logger.Log(level, message);
 
         /// <inheritdoc/>
@@ -159,11 +172,6 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
             _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
             return _daemon!.MediaPlayers(func);
         }
-
-
-
-
-
 
         /// <inheritdoc/>
         public ICamera Camera(params string[] entityIds)
@@ -352,6 +360,19 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         {
             _ = _daemon as INetDaemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
             return _daemon!.DelayUntilStateChange(entityIds, stateFunc);
+        }
+
+
+        /// <summary>
+        ///     Implements the IEqualit.Equals method
+        /// </summary>
+        /// <param name="other">The instance to compare</param>
+        public bool Equals([AllowNull] INetDaemonApp other)
+        {
+            if (other is object && other.Id is object && this.Id is object && this.Id == other.Id)
+                return true;
+
+            return false;
         }
     }
 }

--- a/src/Daemon/NetDaemon.Daemon/Daemon/INetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/INetDaemonHost.cs
@@ -25,7 +25,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         Task Run(string host, short port, bool ssl, string token, CancellationToken cancellationToken);
 
         /// <summary>
-        ///     Stops the netdaemon host asynchronous. 
+        ///     Stops the netdaemon host asynchronous.
         /// </summary>
         /// <returns> The operational task. </returns>
         Task Stop();
@@ -37,7 +37,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         Task StopDaemonActivitiesAsync();
 
         /// <summary>
-        ///     Listens to the given service in the netdaemon domain. Those subscritions 
+        ///     Listens to the given service in the netdaemon domain. Those subscritions
         ///     are used internally and are not postponed during reloading service daemons.
         /// </summary>
         /// <param name="service"> The name of the service. </param>
@@ -51,5 +51,17 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         /// <param name="numberOfRunningApps"> The number of running apps. </param>
         /// <returns></returns>
         Task SetDaemonStateAsync(int numberOfLoadedApps, int numberOfRunningApps);
+
+        /// <summary>
+        ///     Register appinstance with daemon
+        /// </summary>
+        /// <param name="appInstanceId">the id of the app instance</param>
+        /// <param name="app">The app instance</param>
+        void RegisterAppInstance(string appInstanceId, NetDaemonApp app);
+
+        /// <summary>
+        ///     Clears all app instances registered
+        /// </summary>
+        void ClearAppInstances();
     }
 }

--- a/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/NetDaemonHost.cs
@@ -51,6 +51,9 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
         private readonly ConcurrentDictionary<string, (string pattern, Func<string, EntityState?, EntityState?, Task> action)> _stateActions =
             new ConcurrentDictionary<string, (string pattern, Func<string, EntityState?, EntityState?, Task> action)>();
 
+        private readonly ConcurrentDictionary<string, NetDaemonApp> _daemonAppInstances =
+            new ConcurrentDictionary<string, NetDaemonApp>();
+
         private readonly List<string> _supportedDomainsForTurnOnOff = new List<string>
         {
             "light",
@@ -669,6 +672,25 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Daemon
             }
 
             return result;
+        }
+
+        /// <inheritdoc/>
+        public NetDaemonApp? GetApp(string appInstanceId)
+        {
+            return _daemonAppInstances.ContainsKey(appInstanceId) ?
+                _daemonAppInstances[appInstanceId] : null;
+        }
+
+        /// <inheritdoc/>
+        public void RegisterAppInstance(string appInstance, NetDaemonApp app)
+        {
+            _daemonAppInstances[appInstance] = app;
+        }
+
+        /// <inheritdoc/>
+        public void ClearAppInstances()
+        {
+            _daemonAppInstances.Clear();
         }
     }
     public class DelayResult : IDelayResult

--- a/src/DaemonRunner/DaemonRunner/Service/Config/YamlConfig.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/Config/YamlConfig.cs
@@ -35,34 +35,129 @@ namespace JoySoftware.HomeAssistant.NetDaemon.DaemonRunner.Service.Config
         {
             get
             {
+                var result = new List<INetDaemonApp>();
+
                 // For each app instance defined in the yaml config
                 foreach (KeyValuePair<YamlNode, YamlNode> app in (YamlMappingNode)_yamlStream.Documents[0].RootNode)
                 {
-                    if (app.Key.NodeType != YamlNodeType.Scalar ||
-                        app.Value.NodeType != YamlNodeType.Mapping)
+                    string? appId = null;
+                    try
                     {
-                        continue;
-                    }
-
-                    string? appId = ((YamlScalarNode)app.Key).Value;
-                    // Get the class
-
-                    string? appClass = GetTypeNameFromClassConfig((YamlMappingNode)app.Value);
-                    Type appType = _types.Where(n => n.FullName?.ToLowerInvariant() == appClass)
-                                                   .FirstOrDefault();
-
-                    if (appType != null)
-                    {
-                        var instance = InstanceAndSetPropertyConfig(appType, ((YamlMappingNode)app.Value), appId);
-                        if (instance != null)
+                        if (app.Key.NodeType != YamlNodeType.Scalar ||
+                            app.Value.NodeType != YamlNodeType.Mapping)
                         {
-                            instance.Id = appId;
-                            _instances.Add(instance);
+                            continue;
                         }
+
+                        appId = ((YamlScalarNode)app.Key).Value;
+                        // Get the class
+
+                        string? appClass = GetTypeNameFromClassConfig((YamlMappingNode)app.Value);
+                        Type appType = _types.Where(n => n.FullName?.ToLowerInvariant() == appClass)
+                                                       .FirstOrDefault();
+
+                        if (appType != null)
+                        {
+                            var instance = InstanceAndSetPropertyConfig(appType, ((YamlMappingNode)app.Value), appId);
+                            if (instance != null)
+                            {
+                                instance.Id = appId;
+                                result.Add(instance);
+                            }
+                        }
+                    }
+                    catch (System.Exception e)
+                    {
+                        throw new ApplicationException($"Error instancing application {appId}", e);
                     }
                 }
 
+                if (result.SelectMany(n => n.Dependencies).Count() > 0)
+                {
+                    // There are dependecies defined
+                    var edges = new HashSet<Tuple<INetDaemonApp, INetDaemonApp>>();
+
+                    foreach (var instance in result)
+                    {
+                        foreach (var dependency in instance.Dependencies)
+                        {
+                            var dependentApp = result.Where(n => n.Id == dependency).FirstOrDefault();
+                            if (dependentApp == null)
+                                throw new ApplicationException($"There is no app named {dependency}, please check dependencies!");
+
+                            edges.Add(new Tuple<INetDaemonApp, INetDaemonApp>(instance, dependentApp));
+                        }
+                    }
+                    var sortedInstances = TopologicalSort<INetDaemonApp>(result.ToHashSet(), edges) ??
+                        throw new ApplicationException("Application dependencies is wrong, please check dependencies for circular dependencies!");
+
+                    _instances.AddRange(sortedInstances);
+                }
+                else
+                {
+                    _instances.AddRange(result);
+                }
+
                 return _instances;
+
+            }
+        }
+
+        /// <summary>
+        /// Topological Sorting (Kahn's algorithm)
+        /// </summary>
+        /// <remarks>https://en.wikipedia.org/wiki/Topological_sorting</remarks>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="nodes">All nodes of directed acyclic graph.</param>
+        /// <param name="edges">All edges of directed acyclic graph.</param>
+        /// <returns>Sorted node in topological order.</returns>
+        static List<T>? TopologicalSort<T>(HashSet<T> nodes, HashSet<Tuple<T, T>> edges) where T : IEquatable<T>
+        {
+            // Empty list that will contain the sorted elements
+            var L = new List<T>();
+
+            // Set of all nodes with no incoming edges
+            var S = new HashSet<T>(nodes.Where(n => edges.All(e => e.Item2.Equals(n) == false)));
+
+            // while S is non-empty do
+            while (S.Any())
+            {
+
+                //  remove a node n from S
+                var n = S.First();
+                S.Remove(n);
+
+                // add n to tail of L
+                L.Add(n);
+
+                // for each node m with an edge e from n to m do
+                foreach (var e in edges.Where(e => e.Item1.Equals(n)).ToList())
+                {
+                    var m = e.Item2;
+
+                    // remove edge e from the graph
+                    edges.Remove(e);
+
+                    // if m has no other incoming edges then
+                    if (edges.All(me => me.Item2.Equals(m) == false))
+                    {
+                        // insert m into S
+                        S.Add(m);
+                    }
+                }
+            }
+
+            // if graph has edges then
+            if (edges.Any())
+            {
+                // return error (graph has at least one cycle)
+                return null;
+            }
+            else
+            {
+                L.Reverse();
+                // return L (a topologically sorted order)
+                return L;
             }
         }
 

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/Fixtures/dependtests/global_app.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/Fixtures/dependtests/global_app.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JoySoftware.HomeAssistant.NetDaemon.Common;
+
+namespace DependNs
+{
+    public class DependOnGlobalApp : NetDaemonApp
+    {
+        public override Task InitializeAsync()
+        {
+            // Do nothing
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class DependOnGlobalAndOtherApp : NetDaemonApp
+    {
+        public override Task InitializeAsync()
+        {
+            // Do nothing
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class DependOnGlobalOtherApp : NetDaemonApp
+    {
+        public override Task InitializeAsync()
+        {
+            // Do nothing
+
+            return Task.CompletedTask;
+        }
+
+
+    }
+
+    public class GlobalApp : NetDaemonApp
+    {
+        public override Task InitializeAsync()
+        {
+            // Do nothing
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/Fixtures/dependtests/global_app.yaml
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/Fixtures/dependtests/global_app.yaml
@@ -1,0 +1,18 @@
+app_dep_on_global:
+    class: DependNs.DependOnGlobalApp
+    dependencies:
+        - app_global
+
+app_dep_on_global_and_other:
+    class: DependNs.DependOnGlobalApp
+    dependencies:
+        - app_global
+        - app_dep_on_global
+
+app_dep_app_depend_on_global_and_other:
+    class: DependNs.DependOnGlobalApp
+    dependencies:
+        - app_dep_on_global_and_other
+
+app_global:
+    class: DependNs.GlobalApp

--- a/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Demon/NetDaemonHostTests.cs
@@ -527,5 +527,44 @@ namespace NetDaemon.Daemon.Tests.Daemon
             Assert.False(delayResult.Task.Result);
             Assert.Empty(DefaultDaemonHost.InternalStateActions);
         }
+
+        [Fact]
+        public void RegisterAppShouldReturnCorrectAppWhenUsingGetApp()
+        {
+            // ARRANGE
+            DefaultDaemonHost.RegisterAppInstance("appx", new JoySoftware.HomeAssistant.NetDaemon.Common.NetDaemonApp());
+            // ACT
+            var theApp = DefaultDaemonHost.GetApp("appx");
+
+            // ASSERT
+            Assert.NotNull(theApp);
+        }
+
+        [Fact]
+        public void GetAppOnMissingAppShouldReturnNull()
+        {
+            // ARRANGE
+            // ACT
+            var theApp = DefaultDaemonHost.GetApp("noexist");
+
+            // ASSERT
+            Assert.Null(theApp);
+        }
+
+        [Fact]
+        public void ClearShouldReturnNullGetApp()
+        {
+            // ARRANGE
+            DefaultDaemonHost.RegisterAppInstance("appx", new JoySoftware.HomeAssistant.NetDaemon.Common.NetDaemonApp());
+            var theApp = DefaultDaemonHost.GetApp("appx");
+            Assert.NotNull(theApp);
+
+            // ACT
+            DefaultDaemonHost.ClearAppInstances();
+            theApp = DefaultDaemonHost.GetApp("appx");
+
+            // ASSERT
+            Assert.Null(theApp);
+        }
     }
 }


### PR DESCRIPTION
Supports #58 

This PR makes the NetDaemon support to get singleton references to other running instances of an app. 

```csharp
var lightManagerApp = GetApp("light_manager");
```
this also requires support to do dependencies in yaml config
```yaml
app:
   class: MyApp
   dependencies:
      - light_manager
```