### PR TITLE
When state is unavailable the NetDaemon treat is as Null state.

### DIFF
--- a/src/App/NetDaemon.App/NetDaemon.App.csproj
+++ b/src/App/NetDaemon.App/NetDaemon.App.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JoySoftware.HassClient" Version="0.1.1-alpha" />
+    <PackageReference Include="JoySoftware.HassClient" Version="0.1.2-alpha" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
   </ItemGroup>
 

--- a/src/Daemon/NetDaemon.Daemon/NetDaemon.Daemon.csproj
+++ b/src/Daemon/NetDaemon.Daemon/NetDaemon.Daemon.csproj
@@ -20,7 +20,7 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JoySoftware.HassClient" Version="0.1.1-alpha" />
+    <PackageReference Include="JoySoftware.HassClient" Version="0.1.2-alpha" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DaemonRunner/DaemonRunner/DaemonRunner.csproj
+++ b/src/DaemonRunner/DaemonRunner/DaemonRunner.csproj
@@ -21,9 +21,8 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JoySoftware.HassClient" Version="0.1.1-alpha" />
+    <PackageReference Include="JoySoftware.HassClient" Version="0.1.2-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <!-- <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.5.0-beta2-final" /> -->
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->
It can be breaking if you rely on:
```c#
if (entity.State == "unavailable") ...
```
after:
```c#
if (entity.State is null) ...
```
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The changes the behavior for entity states that are `unavailable`. Any state that is unavailable is set to null value. You now do not have to check for unavailable in the scenarios you expect state to be a number as an example.

this code breaks now but will be fine with this PR since state is null when unavailable value to the state. 

```csharp
        public async override Task InitializeAsync() => Entity("sensor.hacs")
                .WhenStateChange((n, o) =>
                    o?.State != n?.State && n?.State > 0)
                        .Call(async (entityId, newState, oldState) =>
                        {
                            var serviceDataTitle = "Updates pending in HACS";
                            var serviceDataMessage = "There are updates pending in [HACS](/hacs)\n\n";


                            List<object> repositories = newState?.Attribute?.repositories || new List<object>();
                            foreach (IDictionary<string, object?> item in repositories)
                            {
                                serviceDataMessage += $"- {item?["display_name"].ToString()}\n";
                            }

                            await CallService("persistent_notification", "create", new
                            {
                                title = serviceDataTitle,
                                message = serviceDataMessage
                            }, true);
                        }).Execute();
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #83 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs