### PR TITLE
Improved experience, warn forget Execute and added symbol info pdb in compile

### DIFF
--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
@@ -338,11 +338,26 @@ app:
 
             moqDaemon.SetupGet(n => n.Logger).Returns(moqLogger.Logger);
             var codeManager = CM(path);
-            codeManager.DaemonAppTypes.Append(typeof(AssmeblyDaemonApp));
             // ACT
             // ASSERT
             var ex = await Assert.ThrowsAsync<ApplicationException>(async () => { await codeManager.InstanceAndInitApplications(moqDaemon.Object); });
             Assert.Contains("Application dependencies is wrong", ex.Message);
+        }
+
+        [Fact]
+        public void InsanceAppsThatHasMissingExecuteShouldLogWarning()
+        {
+            // ARRANGE
+            var path = Path.Combine(FaultyAppPath, "ExecuteWarnings");
+            var moqDaemon = new Mock<INetDaemonHost>();
+            var moqLogger = new LoggerMock();
+
+            // ACT
+            var codeManager = new CodeManager(path, moqLogger.Logger);
+
+            // ASSERT
+            moqLogger.AssertLogged(LogLevel.Warning, Times.Exactly(13));
+
         }
 
         public static CodeManager CM(string path) => new CodeManager(path, new LoggerMock().Logger);

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/ExecuteWarnings/MissingExecuteApp.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/ExecuteWarnings/MissingExecuteApp.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JoySoftware.HomeAssistant.NetDaemon.Common;
+
+/// <summary>
+///     Greets (or insults) people when coming home :)
+/// </summary>
+public class MissingExecuteApp : NetDaemonApp
+{
+    public override async Task InitializeAsync()
+    {
+        // Do nothing
+        Entity("Test");
+
+        Entity("Test").TurnOn();
+
+        await Entity("jalll").TurnOn()
+            .WithAttribute("test", "lslslsl").ExecuteAsync();
+
+        await TestFailInAMethod();
+
+        // Do rest of the needed commands the warning system needs to find
+        Event("test").Call((a, b) => Task.CompletedTask);
+        Events(n => n.EventId.StartsWith("hello_")).Call((a, b) => Task.CompletedTask);
+        InputSelect("i").SetOption("test");
+        InputSelects(n => n.EntityId == "lslsls").SetOption("test");
+        MediaPlayer("i").Play();
+        MediaPlayers(n => n.EntityId == "lslsls").PlayPause();
+        Camera("sasdds").Snapshot("asdas");
+        Cameras(n => n.EntityId == "lslsls").Snapshot("asdas");
+        RunScript("test");
+    }
+
+    private async Task TestFailInAMethod()
+    {
+        await Entity("jalll").TurnOn()
+            .WithAttribute("test", "lslslsl").ExecuteAsync();
+
+        Entity("jalll").WhenStateChange(to: "test")
+                             .AndNotChangeFor(System.TimeSpan.FromSeconds(1))
+                             .Call(async (e, n, o) =>
+       {
+           Entity("Test").TurnOn();
+           var x = new NestedClass(this);
+           await x.DoAThing();
+       });
+
+    }
+}
+
+public class NestedClass
+{
+    private readonly NetDaemonApp _app;
+
+    public NestedClass(NetDaemonApp app)
+    {
+        _app = app;
+    }
+
+    public async Task DoAThing()
+    {
+        // Should find this error
+        _app.Entities(new string[] { "test.test", "test.test2" }).TurnOn();
+    }
+}

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/ExecuteWarnings/MissingExecuteApp.yaml
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/ExecuteWarnings/MissingExecuteApp.yaml
@@ -1,0 +1,3 @@
+
+missing_executes:
+    class: MissingExecuteApp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
### Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Warn users not closing with Execute and ExecuteAsync
Added warning to users if forgetting to close command chains with `.Exectute()` or `.ExecuteAsync()`. This feature will not do that automatically cause it is important the programmer has full control.
Warning will look like

![image](https://user-images.githubusercontent.com/26500160/80280761-6dce1f80-8706-11ea-8df9-e56a62a281c5.png)

## PDB information
Also PDB symbols been added to compilation to show more accurate information when something breaks in user code. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs