### PR TITLE
Added DisableLogs attribute

### DIFF
--- a/src/App/NetDaemon.App/Common/Attributes.cs
+++ b/src/App/NetDaemon.App/Common/Attributes.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace JoySoftware.HomeAssistant.NetDaemon.Common
 {
     /// <summary>
@@ -54,5 +56,43 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common
         ///     To state filter
         /// </summary>
         public object? To => _to;
+    }
+
+    /// <summary>
+    ///     Type of log to supress
+    /// </summary>
+    public enum SupressLogType
+    {
+        /// <summary>
+        ///     Supress Missing Execute Error in a method
+        /// </summary>
+        MissingExecute
+    }
+
+
+    /// <summary>
+    ///     Attribute to mark function as callback for state changes
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public sealed class DisableLogAttribute : System.Attribute
+    {
+        // See the attribute guidelines at
+        //  http://go.microsoft.com/fwlink/?LinkId=85236
+        private SupressLogType[] _logTypesToSupress;
+
+
+        /// <summary>
+        ///     Default constructor
+        /// </summary>
+        /// <param name="logTypes">List of logtypes to supress</param>
+        public DisableLogAttribute(params SupressLogType[] logTypes)
+        {
+            _logTypesToSupress = logTypes;
+        }
+
+        /// <summary>
+        ///     Log types to supress
+        /// </summary>
+        public IEnumerable<SupressLogType> LogTypesToSupress => _logTypesToSupress;
     }
 }

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/App/DaemonAppTests.cs
@@ -360,6 +360,22 @@ app:
 
         }
 
+        [Fact]
+        public void InsanceAppsThatHasMissingExecuteAndSupressLogsShouldNotLogError()
+        {
+            // ARRANGE
+            var path = Path.Combine(FaultyAppPath, "SupressLogs");
+            var moqDaemon = new Mock<INetDaemonHost>();
+            var moqLogger = new LoggerMock();
+
+            // ACT
+            var codeManager = new CodeManager(path, moqLogger.Logger);
+
+            // ASSERT
+            moqLogger.AssertLogged(LogLevel.Error, Times.Exactly(1));
+
+        }
+
         public static CodeManager CM(string path) => new CodeManager(path, new LoggerMock().Logger);
     }
 }

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/SupressLogs/SupressLogs.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/SupressLogs/SupressLogs.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JoySoftware.HomeAssistant.NetDaemon.Common;
+
+/// <summary>
+///     Greets (or insults) people when coming home :)
+/// </summary>
+public class SupressLogs : NetDaemonApp
+{
+    [DisableLog(SupressLogType.MissingExecute)]
+    public override async Task InitializeAsync()
+    {
+        // All  warnings in this is supressed
+        Entity("Test");
+        await DoStuff();
+    }
+
+    public async Task DoStuff()
+    {
+        // This is not supressed
+        Entity("Test");
+    }
+
+}

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/SupressLogs/SupressLogs.yaml
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/FaultyApp/SupressLogs/SupressLogs.yaml
@@ -1,0 +1,3 @@
+
+missing_executes:
+    class: SupressLogs


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In some cases there is a problem with warning users missing Execute and ExecuteAsync. In those cases the users need to have a way to disable those warnings since it is the intent of the code.

The code below shows example of how to supress missing Execute warnings on a function.

```cs

public class SupressLogs : NetDaemonApp
{
    [DisableLog(SupressLogType.MissingExecute)]
    public override async Task InitializeAsync()
    {
        // All  warnings in this is supressed
        Entity("Test");
        await DoStuff();
    }

    public async Task DoStuff()
    {
        // This is not supressed
        Entity("Test");
    }

}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #96 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality chek)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs