### PR TITLE
Save and Get data is brought back inte V2

### DIFF
--- a/src/App/NetDaemon.App/Common/Reactive/AppDaemonRxApp.cs
+++ b/src/App/NetDaemon.App/Common/Reactive/AppDaemonRxApp.cs
@@ -119,6 +119,13 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common.Reactive
         }
 
         /// <inheritdoc/>
+        public T? GetData<T>(string id) where T : class
+        {
+            _ = _daemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            return _daemon.GetDataAsync<T>(id).Result;
+        }
+
+        /// <inheritdoc/>
         public IDisposable RunDaily(string time, Action action)
         {
             DateTime parsedTime;
@@ -227,6 +234,13 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common.Reactive
 
                 _daemon.CallService("script", name);
             }
+        }
+
+        /// <inheritdoc/>
+        public void SaveData<T>(string id, T data)
+        {
+            _ = _daemon ?? throw new NullReferenceException($"{nameof(_daemon)} cant be null!");
+            _daemon.SaveDataAsync<T>(id, data).Wait();
         }
 
         /// <inheritdoc/>

--- a/src/App/NetDaemon.App/Common/Reactive/INetDaemonReactive.cs
+++ b/src/App/NetDaemon.App/Common/Reactive/INetDaemonReactive.cs
@@ -46,6 +46,20 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common.Reactive
         IEnumerable<EntityState> States { get; }
 
         /// <summary>
+        ///     Loads persistent data from unique id
+        /// </summary>
+        /// <param name="id">Unique Id of the data</param>
+        /// <returns>The data persistent or null if not exists</returns>
+        T? GetData<T>(string id) where T : class;
+
+        /// <summary>
+        ///     Saves any data with unique id, data have to be json serializable
+        /// </summary>
+        /// <param name="id">Unique id for all apps</param>
+        /// <param name="data">Dynamic data being saved</param>
+        void SaveData<T>(string id, T data);
+
+        /// <summary>
         ///     Sets a state for entity
         /// </summary>
         /// <param name="entityId">EntityId</param>
@@ -137,6 +151,7 @@ namespace JoySoftware.HomeAssistant.NetDaemon.Common.Reactive
         /// </summary>
         /// <param name="second">The timespan to schedule</param>
         IObservable<long> RunEveryMinute(short second);
+
         /// <summary>
         ///     Delays excecution of an action (timespan) time
         /// </summary>


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bring back GetData/SaveData to V2 (Reactive) API

```c#
// Save state with specific id. Works with any System.Text.Json compatible object
SaveData("unique_id", myobj);

// Gets saved data, returns null if not found
var data = GetData<ObjectClass>("unique_id");

```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs