### PR TITLE
refactor: host builder pipeline logging

### DIFF
--- a/src/DaemonRunner/DaemonRunner/Service/Extensions/HostBuilderExtensions.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/Extensions/HostBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Hosting;
+using NetDaemon.Service.Support;
+using Serilog;
+
+namespace NetDaemon.Service.Extensions
+{
+    public static class HostBuilderExtensions
+    {
+        // We preserve the static logger so that we can access it statically and early on in the application lifecycle.
+        private const bool PreserveStaticLogger = true;
+        
+        public static IHostBuilder UseNetDaemon(this IHostBuilder builder)
+        {
+            return builder
+                .UseNetDaemonSerilog()
+                .ConfigureServices(services =>
+                {
+                    services.AddNetDaemon();
+                });
+        }
+
+        private static IHostBuilder UseNetDaemonSerilog(this IHostBuilder builder)
+        {
+            return builder.UseSerilog(
+                (context, configuration) => SeriLogConfigurator.Configure(configuration),
+                PreserveStaticLogger
+            );
+        }
+    }
+}

--- a/src/DaemonRunner/DaemonRunner/Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace NetDaemon.Service.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddNetDaemon(this IServiceCollection services)
+        {
+            services.AddHttpClient();
+            services.AddHostedService<RunnerService>();
+
+            return services;
+        }
+    }
+}

--- a/src/DaemonRunner/DaemonRunner/Service/Runner.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/Runner.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NetDaemon.Service.Extensions;
+using NetDaemon.Service.Support;
+using Serilog;
+
+namespace NetDaemon.Service
+{
+    public static class Runner
+    {
+        private const string _hassioConfigPath = "/data/options.json";
+
+        public static IHostBuilder CreateHostBuilder(string[] args) => 
+            Host.CreateDefaultBuilder(args)
+                .UseNetDaemon();
+        
+        public static async Task Run(string[] args)
+        {
+            try
+            {
+                Log.Logger = SeriLogConfigurator.GetConfiguration().CreateLogger();
+
+                if (File.Exists(_hassioConfigPath))
+                {
+                    try
+                    {
+                        var hassAddOnSettings = await JsonSerializer.DeserializeAsync<HassioConfig>(
+                            File.OpenRead(_hassioConfigPath)).ConfigureAwait(false);
+                        if (hassAddOnSettings.LogLevel is object)
+                        {
+                            SeriLogConfigurator.SetMinimumLogLevel(hassAddOnSettings.LogLevel);
+                        }
+                        if (hassAddOnSettings.GenerateEntitiesOnStart is object)
+                        {
+                            Environment.SetEnvironmentVariable("HASS_GEN_ENTITIES", hassAddOnSettings.GenerateEntitiesOnStart.ToString());
+                        }
+                        if (hassAddOnSettings.LogMessages is object && hassAddOnSettings.LogMessages == true)
+                        {
+                            Environment.SetEnvironmentVariable("HASSCLIENT_MSGLOGLEVEL", "Default");
+                        }
+                        if (hassAddOnSettings.ProjectFolder is object &&
+                            string.IsNullOrEmpty(hassAddOnSettings.ProjectFolder) == false)
+                        {
+                            Environment.SetEnvironmentVariable("HASS_RUN_PROJECT_FOLDER", hassAddOnSettings.ProjectFolder);
+                        }
+
+                        // We are in Hassio so hard code the path
+                        Environment.SetEnvironmentVariable("HASS_DAEMONAPPFOLDER", "/config/netdaemon");
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Fatal(e, "Failed to read the Home Assistant Add-on config");
+                    }
+                }
+                else
+                {
+                    var envLogLevel = Environment.GetEnvironmentVariable("HASS_LOG_LEVEL");
+                    if (!string.IsNullOrEmpty(envLogLevel))
+                    {
+                        SeriLogConfigurator.SetMinimumLogLevel(envLogLevel);
+                    }
+                }
+
+                await CreateHostBuilder(args).Build().RunAsync();
+            }
+            catch (Exception e)
+            {
+                Log.Fatal(e, "Failed to start host...");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+    }
+}

--- a/src/DaemonRunner/DaemonRunner/Service/Support/SeriLogConfigurator.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/Support/SeriLogConfigurator.cs
@@ -1,0 +1,39 @@
+﻿using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
+
+namespace NetDaemon.Service.Support
+{
+    internal static class SeriLogConfigurator
+    {
+        private static readonly LoggingLevelSwitch LevelSwitch = new LoggingLevelSwitch();
+
+        public static LoggerConfiguration GetConfiguration()
+        {
+            return Configure(new LoggerConfiguration());
+        }
+        
+        public static LoggerConfiguration Configure(LoggerConfiguration configuration)
+        {
+            return configuration
+                .MinimumLevel.ControlledBy(LevelSwitch)
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .Enrich.FromLogContext()
+                .WriteTo.Console(theme: AnsiConsoleTheme.Code);
+        }
+
+        public static void SetMinimumLogLevel(string level)
+        {
+            LevelSwitch.MinimumLevel = level switch
+            {
+                "info" => LogEventLevel.Information,
+                "debug" => LogEventLevel.Debug,
+                "error" => LogEventLevel.Error,
+                "warning" => LogEventLevel.Warning,
+                "trace" => LogEventLevel.Verbose,
+                _ => LogEventLevel.Information
+            };
+        }
+    }
+}


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change moves implementations to multiple, more sensible components. It also configures SeriLog correctly in the host builder pipeline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Currently there's a lot of logic in the `Runner` class, for example the loading of configuration and setting log levels. We should decouple this and load configuration at a later stage (when the app starts) so that the host builder pipeline can be as clean as possible. This change moves logging responsibilities to a different class and unifies the configuration of it. I also added some extension methods that can configure the host builder pipeline for NetDaemon correctly. The next step is to extract the configuration loading.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.