### PR TITLE
Use property to check for dynamic assemblies

### DIFF
--- a/src/DaemonRunner/DaemonRunner/Service/App/DaemonCompiler.cs
+++ b/src/DaemonRunner/DaemonRunner/Service/App/DaemonCompiler.cs
@@ -125,9 +125,7 @@ namespace NetDaemon.Service.App
             var assembliesFromCurrentAppDomain = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var assembly in assembliesFromCurrentAppDomain)
             {
-                if (assembly.FullName != null
-                    && !assembly.FullName.Contains("Dynamic")
-                    && !string.IsNullOrEmpty(assembly.Location))
+                if (!assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
                     metaDataReference.Add(MetadataReference.CreateFromFile(assembly.Location));
             }
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I had some failing tests locally caused by dynamic assemblies not actually having *Dynamic* in their name:
![image](https://user-images.githubusercontent.com/5957362/87169627-8e9f1d80-c2d0-11ea-96f0-8e26f3203ecc.png)

To fix this we should correctly check whether an assembly is dynamic or not by using the property exposed on the assembly class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.