### PR TITLE
Bugfix: arrays in attributes not returned in entity

### DIFF
--- a/src/Daemon/NetDaemon.Daemon/Infrastructure/Extensions/JsonElementExtensions.cs
+++ b/src/Daemon/NetDaemon.Daemon/Infrastructure/Extensions/JsonElementExtensions.cs
@@ -6,7 +6,7 @@ namespace NetDaemon.Infrastructure.Extensions
 {
     internal static class JsonElementExtensions
     {
-        public static object? ToDynamicValue(this JsonElement elem)
+        public static object? ConvertToDynamicValue(this JsonElement elem)
         {
             switch (elem.ValueKind)
             {
@@ -31,7 +31,7 @@ namespace NetDaemon.Infrastructure.Extensions
                     var list = new List<object?>();
                     foreach (var val in elem.EnumerateArray())
                     {
-                        list.Add(val.ToDynamicValue());
+                        list.Add(val.ConvertToDynamicValue());
                     }
                     return (IEnumerable<object?>)list;
 
@@ -40,7 +40,7 @@ namespace NetDaemon.Infrastructure.Extensions
 
                     foreach (var prop in elem.EnumerateObject())
                     {
-                        obj[prop.Name] = prop.Value.ToDynamicValue();
+                        obj[prop.Name] = prop.Value.ConvertToDynamicValue();
                     }
                     return (IDictionary<string, object?>)obj;
             }

--- a/src/Daemon/NetDaemon.Daemon/Mapping/EntityStateMapper.cs
+++ b/src/Daemon/NetDaemon.Daemon/Mapping/EntityStateMapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using JoySoftware.HomeAssistant.Client;
+using NetDaemon.Infrastructure.Extensions;
 using NetDaemon.Common;
 
 namespace NetDaemon.Mapping
@@ -45,7 +46,7 @@ namespace NetDaemon.Mapping
             {
                 if (value is JsonElement elem)
                 {
-                    var dynValue = elem.ToDynamicValue();
+                    var dynValue = elem.ConvertToDynamicValue();
 
                     if (dynValue != null)
                         dict[key] = dynValue;

--- a/tests/NetDaemon.Daemon.Tests/Daemon/ExtensionMethodsTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/Daemon/ExtensionMethodsTests.cs
@@ -19,7 +19,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("str");
 
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
 
             // ASSERT
             Assert.IsType<string>(obj);
@@ -34,7 +34,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("bool");
 
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
 
             // ASSERT
             Assert.IsType<bool>(obj);
@@ -49,7 +49,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("bool");
 
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
 
             // ASSERT
             Assert.IsType<bool>(obj);
@@ -64,7 +64,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("int");
             long expectedValue = 10;
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
 
             // ASSERT
             Assert.IsType<long>(obj);
@@ -79,7 +79,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("int");
             double expectedValue = 10.5;
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
 
             // ASSERT
             Assert.IsType<double>(obj);
@@ -94,7 +94,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var prop = doc.RootElement.GetProperty("array");
 
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(prop);
+            var obj = JsonElementExtensions.ConvertToDynamicValue(prop);
             var arr = obj as IEnumerable<object?>;
 
             // ASSERT
@@ -109,7 +109,7 @@ namespace NetDaemon.Daemon.Tests.Daemon
             var doc = JsonDocument.Parse("{\"str\": \"string\"}");
 
             // ACT
-            var obj = JsonElementExtensions.ToDynamicValue(doc.RootElement) as IDictionary<string, object?>;
+            var obj = JsonElementExtensions.ConvertToDynamicValue(doc.RootElement) as IDictionary<string, object?>;
 
             // ASSERT
             Assert.Equal("string", obj?["str"]);


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #252 
The entity_id array is not returned when getting state from groups. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #252
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs