### PR TITLE
NDFirstOrTimeout and Delay implementation

### DIFF
--- a/src/App/NetDaemon.App/Common/Reactive/INetDaemonReactive.cs
+++ b/src/App/NetDaemon.App/Common/Reactive/INetDaemonReactive.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using NetDaemon.Common.Fluent;
 
 namespace NetDaemon.Common.Reactive
@@ -73,6 +74,25 @@ namespace NetDaemon.Common.Reactive
         /// </summary>
         /// <param name="script">Script to call</param>
         void RunScript(params string[] script);
+
+        /// <summary>
+        ///     Delays timeout time
+        /// </summary>
+        /// <remarks>
+        ///     When the app stops it will cancel wait with OperationanceledException
+        /// </remarks>
+        /// <param name="timeout">Time to delay execution</param>
+        void Delay(TimeSpan timeout);
+
+        /// <summary>
+        ///     Delays timeout time
+        /// </summary>
+        /// <remarks>
+        ///     When the app stops it will cancel wait with OperationanceledException
+        /// </remarks>
+        /// <param name="timeout">Time to delay execution</param>
+        /// <param name="token">Token to cancel any delays</param>
+        void Delay(TimeSpan timeout, CancellationToken token);
     }
 
     /// <summary>

--- a/src/App/NetDaemon.App/Common/Reactive/ObservableExtensionMethods.cs
+++ b/src/App/NetDaemon.App/Common/Reactive/ObservableExtensionMethods.cs
@@ -37,5 +37,23 @@ namespace NetDaemon.Common.Reactive
         public static IObservable<(EntityState Old, EntityState New)> NDWaitForState(this IObservable<(EntityState Old, EntityState New)> observable) => observable
             .Timeout(TimeSpan.FromSeconds(5),
             Observable.Return((new EntityState() { State = "TimeOut" }, new EntityState() { State = "TimeOut" }))).Take(1);
+
+
+        /// <summary>
+        ///     Returns first occurence or null if timedout
+        /// </summary>
+        /// <param name="observable">Extended object</param>
+        /// <param name="timeout">The time to wait before timeout.</param>
+        public static (EntityState Old, EntityState New)? NDFirstOrTimeout(this IObservable<(EntityState Old, EntityState New)> observable, TimeSpan timeout)
+        {
+            try
+            {
+                return observable.Timeout(timeout).Take(1).Wait();
+            }
+            catch (TimeoutException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
+++ b/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
@@ -442,10 +442,10 @@ namespace NetDaemon.Daemon.Tests.Reactive
             // ACT
             DefaultDaemonRxApp.Entity("binary_sensor.pir")
                 .StateChanges
-                .Subscribe(_ => result = DefaultDaemonRxApp.Entity("binary_sensor.pir2").StateChanges.NDFirstOrTimeout(TimeSpan.FromMilliseconds(100)));
+                .Subscribe(_ => result = DefaultDaemonRxApp.Entity("binary_sensor.pir2").StateChanges.NDFirstOrTimeout(TimeSpan.FromMilliseconds(200)));
 
             DefaultHassClientMock.AddChangedEvent("binary_sensor.pir", "off", "on");
-            await Task.Delay(50).ConfigureAwait(false);
+            await Task.Delay(100).ConfigureAwait(false);
             DefaultHassClientMock.AddChangedEvent("binary_sensor.pir2", "on", "off");
 
             await RunFakeDaemonUntilTimeout().ConfigureAwait(false);

--- a/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
+++ b/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
@@ -414,7 +414,8 @@ namespace NetDaemon.Daemon.Tests.Reactive
             // ACT
             DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100), tokenSource.Token);
             // ASSERT
-            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 90;
+            // Compensate that windows resolution is 15ms for system clock
+            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 84;
             Assert.True(isAfterTimeout);
         }
 
@@ -425,7 +426,8 @@ namespace NetDaemon.Daemon.Tests.Reactive
             var startTime = DateTime.Now;
             // ACT
             DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100));
-            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 90;
+            // Compensate that windows resolution is 15ms for system clock
+            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 84;
             // ASSERT
             Assert.True(isAfterTimeout);
         }

--- a/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
+++ b/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
@@ -409,28 +409,25 @@ namespace NetDaemon.Daemon.Tests.Reactive
         public void DelayShouldDelaySyncronyslyWithToken()
         {
             // ARRANGE
-            Stopwatch s = new();
+            var startTime = DateTime.Now;
             using var tokenSource = new CancellationTokenSource();
-            // ARRANGE
-            s.Start();
             // ACT
             DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100), tokenSource.Token);
-            s.Stop();
             // ASSERT
-            Assert.NotInRange(s.ElapsedMilliseconds, 0, 99);
+            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 90;
+            Assert.True(isAfterTimeout);
         }
 
         [Fact]
         public void DelayShouldDelaySyncronysly()
         {
             // ARRANGE
-            Stopwatch s = new();
-            s.Start();
+            var startTime = DateTime.Now;
             // ACT
             DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100));
-            s.Stop();
+            bool isAfterTimeout = DateTime.Now.Subtract(startTime).TotalMilliseconds >= 90;
             // ASSERT
-            Assert.NotInRange(s.ElapsedMilliseconds, 0, 99);
+            Assert.True(isAfterTimeout);
         }
 
         [Fact]

--- a/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
+++ b/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
@@ -414,10 +414,10 @@ namespace NetDaemon.Daemon.Tests.Reactive
             // ARRANGE
             s.Start();
             // ACT
-            DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(50), tokenSource.Token);
+            DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100), tokenSource.Token);
             s.Stop();
             // ASSERT
-            Assert.NotInRange(s.ElapsedMilliseconds, 0, 49);
+            Assert.NotInRange(s.ElapsedMilliseconds, 0, 99);
         }
 
         [Fact]
@@ -427,10 +427,10 @@ namespace NetDaemon.Daemon.Tests.Reactive
             Stopwatch s = new();
             s.Start();
             // ACT
-            DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(50));
+            DefaultDaemonRxApp.Delay(TimeSpan.FromMilliseconds(100));
             s.Stop();
             // ASSERT
-            Assert.NotInRange(s.ElapsedMilliseconds, 0, 49);
+            Assert.NotInRange(s.ElapsedMilliseconds, 0, 99);
         }
 
         [Fact]

--- a/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
+++ b/tests/NetDaemon.Daemon.Tests/Reactive/RxAppTest.cs
@@ -447,7 +447,7 @@ namespace NetDaemon.Daemon.Tests.Reactive
                 .StateChanges
                 .Subscribe(_ =>
                 {
-                    waitFor.CancelAfter(20);
+                    waitFor.CancelAfter(100);
                     result = DefaultDaemonRxApp.Entity("binary_sensor.pir2").StateChanges.NDFirstOrTimeout(TimeSpan.FromMilliseconds(300));
                 });
 

--- a/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
@@ -345,7 +345,7 @@ namespace NetDaemon.Daemon.Tests
 
                 // ASSERT
                 Assert.True(nrOfRuns == 0);
-                await Task.Delay(800).ConfigureAwait(false);
+                await Task.Delay(1000).ConfigureAwait(false);
                 Assert.True(nrOfRuns >= 1);
             }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add safe delay and able to wait for observable or timeout in blocking way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #198
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs