### PR TITLE
Fixes syntax and added EntityState property on gen

### DIFF
--- a/src/App/NetDaemon.App/Common/Reactive/ObservableExtensionMethods.cs
+++ b/src/App/NetDaemon.App/Common/Reactive/ObservableExtensionMethods.cs
@@ -38,7 +38,6 @@ namespace NetDaemon.Common.Reactive
             .Timeout(TimeSpan.FromSeconds(5),
             Observable.Return((new EntityState() { State = "TimeOut" }, new EntityState() { State = "TimeOut" }))).Take(1);
 
-
         /// <summary>
         ///     Returns first occurence or null if timedout
         /// </summary>

--- a/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
+++ b/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
@@ -312,6 +312,7 @@ namespace NetDaemon.Daemon.Fakes
         /// <param name="entityId">Unique id of entity</param>
         /// <param name="state">State to set</param>
         /// <param name="attributes">Attributes provided</param>
+        /// <param name="times">Times called</param>
         public void VerifySetState(string entityId, dynamic? state = null, dynamic? attributes = null, Times? times = null)
         {
             if (attributes is not null && attributes is not object)

--- a/tests/NetDaemon.Daemon.Tests/DaemonRunner/CodeGen/CodeGenTestFixture.cs
+++ b/tests/NetDaemon.Daemon.Tests/DaemonRunner/CodeGen/CodeGenTestFixture.cs
@@ -5,8 +5,8 @@ namespace Netdaemon.Generated.Extensions
 {
     public static partial class EntityExtension
     {
-        public static LightEntities LightEx(this NetDaemonApp app) => new LightEntities(app);
-        public static MediaPlayerEntities MediaPlayerEx(this NetDaemonApp app) => new MediaPlayerEntities(app);
+        public static LightEntities LightEntities(this NetDaemonApp app) => new(app);
+        public static MediaPlayerEntities MediaPlayerEntities(this NetDaemonApp app) => new(app);
     }
 
     public partial class LightEntities

--- a/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/SchedulerTests.cs
@@ -341,12 +341,12 @@ namespace NetDaemon.Daemon.Tests
                        nrOfRuns++;
                        await Task.Delay(1).ConfigureAwait(false);
                    });
-                await Task.Delay(600).ConfigureAwait(false);
+                await Task.Delay(200).ConfigureAwait(false);
 
                 // ASSERT
-                Assert.True(nrOfRuns == 0);
-                await Task.Delay(1000).ConfigureAwait(false);
-                Assert.True(nrOfRuns >= 1);
+                Assert.Equal(0, nrOfRuns);
+                await Task.Delay(1200).ConfigureAwait(false);
+                Assert.Equal(1, nrOfRuns);
             }
 
             try


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- New property (EntityState) on generated entities to allow extension methods on Entities for exeample
- Clean up code to match C#9 and remove warnings
- Fix bug that generated wrong interface after moving to `INetDaemonRxApp`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #270
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs