### PR TITLE
Added State() Functionality to RxAppMock

### DIFF
--- a/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
+++ b/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
@@ -51,6 +51,8 @@ namespace NetDaemon.Daemon.Fakes
                 return m.Object;
             });
 
+            Setup(n => n.State(It.IsAny<string>())).Returns<string>(entityId => MockState.First(state => state.EntityId == entityId));
+
             Setup(n => n.Entities(It.IsAny<string[]>())).Returns<string[]>(entityIds =>
             {
                 var m = new Mock<IRxEntityBase>();
@@ -118,6 +120,12 @@ namespace NetDaemon.Daemon.Fakes
         /// <param name="newState">New state</param>
         public void TriggerStateChange(EntityState oldState, EntityState newState)
         {
+            var state = MockState.FirstOrDefault(entity => entity.EntityId == newState.EntityId);
+            var index = MockState.IndexOf(state!);
+
+            if (index != -1)
+                MockState[index] = newState;
+
             // Call the observable with no blocking
             foreach (var observer in ((StateChangeObservable)StateChangesObservable).Observers)
             {
@@ -131,6 +139,7 @@ namespace NetDaemon.Daemon.Fakes
                     throw;
                 }
             }
+            
         }
 
         /// <summary>

--- a/tests/NetDaemon.Daemon.Tests/FakesTests/FakeMockableApp.cs
+++ b/tests/NetDaemon.Daemon.Tests/FakesTests/FakeMockableApp.cs
@@ -64,6 +64,14 @@ namespace NetDaemon.Daemon.Tests.Reactive
 
             _app.SetState("sensor.any_sensor", 20, new { battery_level = 70 });
             _app.SetState("sensor.any_sensor2", 20, new { battery_level = 70 });
+
+            _app.Entity("binary_sensor.test_state_entity")
+                .StateChanges
+                .Subscribe(_ => {
+                    if (_app.State("sensor.some_other_entity")?.State == "on")
+                        _app.Entity("light.state_light").TurnOn();
+                });
         }
+
     }
 }

--- a/tests/NetDaemon.Daemon.Tests/FakesTests/RxMockTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/FakesTests/RxMockTests.cs
@@ -93,6 +93,25 @@ namespace NetDaemon.Daemon.Tests.Reactive
         }
 
         [Fact]
+        public void TestFakeMockableGetStateForEntity()
+        {
+            // ARRANGE
+            FakeMockableAppImplementation app = new(Object);
+            // Have to add the entity before initialize to support lambda selections
+            MockState.Add(new() { EntityId = "sensor.some_other_entity" });
+            MockState.Add(new() { EntityId = "binary_sensor.test_state_entity" });
+
+            app.Initialize();
+
+            // ACT
+            TriggerStateChange("sensor.some_other_entity", "off", "on");
+            TriggerStateChange("binary_sensor.test_state_entity", "off", "on");
+
+            // ASSERT
+            VerifyEntityTurnOn("light.state_light");
+        }
+
+        [Fact]
         public void TestFakeMockableBinarySensorAppEntitiesFalse()
         {
             // ARRANGE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This allows you to get the State of an Entity when using RxAppMock `State("entity.some_id")`

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality check)
- [X] Tests have been added to verify that the new code works.
