### PR TITLE
Bugfix: Pass correct NetDeamonApp into Entities constructors

### DIFF
--- a/src/Daemon/NetDaemon.Daemon/Daemon/Config/YamlAppConfig.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/Config/YamlAppConfig.cs
@@ -96,7 +96,7 @@ namespace NetDaemon.Daemon.Config
 
                     var valueType = entry.Value.NodeType;
 
-                    var instance = InstanceProperty(netDaemonApp, prop.PropertyType, entry.Value);
+                    var instance = InstanceProperty(netDaemonApp, netDaemonApp, prop.PropertyType, entry.Value);
 
                     prop.SetValue(netDaemonApp, instance);
                 }
@@ -110,13 +110,13 @@ namespace NetDaemon.Daemon.Config
         }
 
         [SuppressMessage("", "CA1508")] // Weird bug that this should not warn!
-        private object? InstanceProperty(object? parent, Type instanceType, YamlNode node)
+        private object? InstanceProperty(INetDaemonAppBase deamonApp, object? parent, Type instanceType, YamlNode node)
         {
             if (node.NodeType == YamlNodeType.Scalar)
             {
                 var scalarNode = (YamlScalarNode)node;
                 ReplaceSecretIfExists(scalarNode);
-                return ((YamlScalarNode)node).ToObject(instanceType,parent);
+                return ((YamlScalarNode)node).ToObject(instanceType, deamonApp);
             }
             else if (node.NodeType == YamlNodeType.Sequence)
             {
@@ -130,7 +130,7 @@ namespace NetDaemon.Daemon.Config
 
                     foreach (YamlNode item in ((YamlSequenceNode)node).Children)
                     {
-                        var instance = InstanceProperty(null, listType, item) ??
+                        var instance = InstanceProperty(deamonApp, null, listType, item) ??
                                     throw new NotSupportedException($"The class {parent?.GetType().Name} has wrong type in items");
 
                         list.Add(instance);
@@ -158,12 +158,12 @@ namespace NetDaemon.Daemon.Config
                     switch (valueType)
                     {
                         case YamlNodeType.Sequence:
-                            result = InstanceProperty(instance, childProp.PropertyType, (YamlSequenceNode)entry.Value);
+                            result = InstanceProperty(deamonApp, instance, childProp.PropertyType, (YamlSequenceNode)entry.Value);
 
                             break;
 
                         case YamlNodeType.Scalar:
-                            result = InstanceProperty(instance, childProp.PropertyType, (YamlScalarNode)entry.Value);
+                            result = InstanceProperty(deamonApp, instance, childProp.PropertyType, (YamlScalarNode)entry.Value);
                             break;
 
                         case YamlNodeType.Mapping:

--- a/src/Daemon/NetDaemon.Daemon/Daemon/Config/YamlExtensions.cs
+++ b/src/Daemon/NetDaemon.Daemon/Daemon/Config/YamlExtensions.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using NetDaemon.Common;
 using NetDaemon.Common.Exceptions;
 using NetDaemon.Common.Reactive;
 using NetDaemon.Common.Reactive.Services;
@@ -37,7 +38,7 @@ namespace NetDaemon.Daemon.Config
             return type.GetProperty(propertyName) ?? type.GetProperty(propertyName.ToCamelCase());
         }
 
-        public static object? ToObject(this YamlScalarNode node, Type valueType, object? parent)
+        public static object? ToObject(this YamlScalarNode node, Type valueType, INetDaemonAppBase deamonApp)
         {
             _ = valueType ??
                 throw new NetDaemonArgumentNullException(nameof(valueType));
@@ -113,8 +114,7 @@ namespace NetDaemon.Daemon.Config
 
             if (valueType.IsAssignableTo(typeof(RxEntityBase)))
             {
-                var instance =  Activator.CreateInstance(valueType,parent , new[] {node.Value});
-                return instance;
+                return Activator.CreateInstance(valueType, deamonApp, new[] {node.Value});
             }
             return null;
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #335
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs