### PR TITLE
add SaveData and GetData setups to tests

### DIFF
--- a/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
+++ b/src/Fakes/NetDaemon.Fakes/RxAppMock.cs
@@ -37,6 +37,8 @@ namespace NetDaemon.Daemon.Fakes
         /// </summary>
         public TestScheduler TestScheduler { get; } = new();
 
+        private readonly IDictionary<string, object> _mockDataRepository = new Dictionary<string, object>();
+
         /// <summary>
         ///     Default constructor
         /// </summary>
@@ -161,6 +163,12 @@ namespace NetDaemon.Daemon.Fakes
                     Observable.Timer(span, TestScheduler)
                         .Subscribe(_ => action());
                 });
+
+            Setup(s => s.SaveData(It.IsAny<string>(), It.IsAny<object>()))
+                    .Callback<string, object>((id, data) => _mockDataRepository.Add(id, data));
+
+            Setup(s => s.GetData<object>(It.IsAny<string>()))
+                    .Returns<string>(id => _mockDataRepository.TryGetValue(id, out var value) ? value : null);
         }
 
         private void UpdateMockState(string[] entityIds, string newState, object? attributes)

--- a/tests/NetDaemon.Daemon.Tests/FakesTests/RxMockTests.cs
+++ b/tests/NetDaemon.Daemon.Tests/FakesTests/RxMockTests.cs
@@ -358,5 +358,31 @@ namespace NetDaemon.Daemon.Tests.Reactive
             // ASSERT
             VerifyCallService("notify", "notify", Times.Once());
         }
+
+        [Fact]
+        public void TestSaveAndGetData()
+        {
+            // ARRANGE
+            const string id = "id";
+
+            var testData = new TestData()
+            {
+                Value = "test_value"
+            };
+
+                // ACT
+            Object.SaveData(id, testData);
+
+            var savedObject = Object.GetData<TestData>(id);
+
+            // ASSERT
+            Assert.NotNull(savedObject);
+            Assert.Equal(testData.Value, savedObject!.Value);
+        }
+
+        private class TestData
+        {
+            public string? Value { get; init; }
+        }
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
adding  SaveData and GetData setups to RxAppMock


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs