### PR TITLE
Remove annoying http client informational logging

### DIFF
--- a/src/DaemonRunner/DaemonRunner/Infrastructure/Config/SerilogConfigurator.cs
+++ b/src/DaemonRunner/DaemonRunner/Infrastructure/Config/SerilogConfigurator.cs
@@ -21,12 +21,12 @@ namespace NetDaemon.Infrastructure.Config
                throw new NetDaemonArgumentNullException(nameof(hostingEnvironment));
 
             var loggingConfiguration = GetLoggingConfiguration(hostingEnvironment);
-
             SetMinimumLogLevel(loggingConfiguration.MinimumLevel);
 
             return loggerConfiguration
                 .MinimumLevel.ControlledBy(LevelSwitch)
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("System.Net.Http.HttpClient", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .WriteTo.Console(theme: NetDaemonConsoleThemes.GetThemeByType(loggingConfiguration.ConsoleThemeType), applyThemeToRedirectedOutput: true);
         }

--- a/src/Service/_appsettings.Development.json
+++ b/src/Service/_appsettings.Development.json
@@ -1,6 +1,12 @@
 ﻿{
     "Logging": {
-        "MinimumLevel": "Debug",
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {
+              "System.Net.Http.HttpClient": "Warning",
+              "Microsoft": "Warning"
+            }
+        },
         "ConsoleThemeType": "System"
     },
     "HomeAssistant": {

--- a/src/Service/appsettings.json
+++ b/src/Service/appsettings.json
@@ -1,6 +1,12 @@
 {
     "Logging": {
-        "MinimumLevel": "Info",
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+              "System.Net.Http.HttpClient": "Warning",
+              "Microsoft": "Warning"
+            }
+        },
         "ConsoleThemeType": "Ansi"
     },
     "HomeAssistant": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the annoying informational logging of all httpclient communication

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs