### PR TITLE
Exposes the schedulers time in scheduling API

### DIFF
--- a/src/Extensions/NetDaemon.Extensions.Scheduling.Tests/Scheduling/SchedulingTests.cs
+++ b/src/Extensions/NetDaemon.Extensions.Scheduling.Tests/Scheduling/SchedulingTests.cs
@@ -208,5 +208,20 @@ namespace NetDaemon.Extensions.Scheduling.Tests
                     It.IsAny<Exception>(),
                     It.Is<Func<It.IsAnyType, Exception, string>>((_, _) => true)), Times.Exactly(4));
         }
+
+        [Fact]
+        public void TestNowIsCorrectTime()
+        {
+            // ARRANGE
+            var testScheduler = new TestScheduler();
+            // sets the date to a specific time 
+            var dueTime = new DateTime(2021, 1, 1, 0, 0, 0);
+            testScheduler.AdvanceTo(dueTime.Ticks);
+
+            var netDaemonScheduler = new NetDaemonScheduler(reactiveScheduler: testScheduler);
+
+            // ACT & ASSERT
+            Assert.Equal(testScheduler.Now, netDaemonScheduler.Now);
+        }
     }
 }

--- a/src/Extensions/NetDaemon.Extensions.Scheduling/INetDaemonScheduler.cs
+++ b/src/Extensions/NetDaemon.Extensions.Scheduling/INetDaemonScheduler.cs
@@ -35,5 +35,10 @@ namespace NetDaemon.Extensions.Scheduler
         /// <param name="timeOffset">Absolute time to run the action</param>
         /// <param name="action">Action to run</param>
         IDisposable RunAt(DateTimeOffset timeOffset, Action action);
+
+        /// <summary>
+        ///     The current time of the scheduler
+        /// </summary>
+        DateTimeOffset Now { get; }
     }
 }

--- a/src/Extensions/NetDaemon.Extensions.Scheduling/NetDaemonScheduler.cs
+++ b/src/Extensions/NetDaemon.Extensions.Scheduling/NetDaemonScheduler.cs
@@ -104,6 +104,9 @@ namespace NetDaemon.Extensions.Scheduler
             return result;
         }
 
+        /// <inheritdoc/>
+        public DateTimeOffset Now => _reactiveScheduler.Now;
+
         [SuppressMessage("", "CA1031")]
         private void RunAction(Action action)
         {


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the schedulers time as part of the itnerface. This can come in handy especially when using the scheduler in testing. Any extension on this scheduler should use this Time instead of the DateTime one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs