### PR TITLE
Add xml comments to the generated code based on HA matadata

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.Entitites.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.Entitites.cs
@@ -59,7 +59,7 @@ namespace NetDaemon.HassModel.CodeGenerator
             return Interface("IEntities").AddMembers(autoProperties).ToPublic();
         }
 
-        // The Entites class that provides properties to all Domains
+        // The Entities class that provides properties to all Domains
         private static TypeDeclarationSyntax GenerateRootEntitiesClass(IEnumerable<EntitySet> entitySet)
         {
             var haContextNames = GetNames<IHaContext>();
@@ -159,8 +159,11 @@ namespace NetDaemon.HassModel.CodeGenerator
 
             var propertyCode = $@"{className} {entityName.ToNormalizedPascalCase((string)"E_")} => new(_{GetNames<IHaContext>().VariableName}, ""{entity.EntityId}"");";
 
-            return ParseProperty(propertyCode).ToPublic();
+            var name = entity.AttributesAs<attributes>()?.friendly_name;
+            return ParseProperty(propertyCode).ToPublic().WithSummaryComment(name);
         }
+
+        record attributes(string friendly_name);
 
         private static bool IsNumeric(HassState entity)
         {

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.ExtensionMethods.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.ExtensionMethods.cs
@@ -52,10 +52,11 @@ namespace NetDaemon.HassModel.CodeGenerator
             var entityTypeName = GetDomainEntityTypeName(service.Target?.Entity?.Domain!);
 
             yield return ParseMethod(
-                $@"void {GetServiceMethodName(serviceName)}(this {entityTypeName} entity {(serviceArguments is not null ? $", {serviceArguments.GetParametersString()}" : string.Empty)})
+                    $@"void {GetServiceMethodName(serviceName)}(this {entityTypeName} entity {(serviceArguments is not null ? $", {serviceArguments.GetParametersString()}" : string.Empty)})
             {{
                 entity.CallService(""{serviceName}""{(serviceArguments is not null ? $", {serviceArguments.GetParametersVariable()}" : string.Empty)});
-            }}").ToPublic().ToStatic();
+            }}").ToPublic().ToStatic()
+                .WithSummaryComment(service.Description);
 
             if (serviceArguments is not null)
             {
@@ -63,7 +64,10 @@ namespace NetDaemon.HassModel.CodeGenerator
                     $@"void {GetServiceMethodName(serviceName)}(this {entityTypeName} entity, {serviceArguments.GetParametersDecomposedString()})
                 {{
                     entity.CallService(""{serviceName}"", {serviceArguments.GetParametersDecomposedVariable()});
-                }}").ToPublic().ToStatic();
+                }}").ToPublic().ToStatic()
+                    .WithSummaryComment(service.Description)
+                    .WithParameterComment("entity", $"The {entityTypeName} to call this service for")
+                    .WithParameterComments(serviceArguments);
             }
         }
     }

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/HassServiceArgumentMapper.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/HassServiceArgumentMapper.cs
@@ -13,7 +13,8 @@ namespace NetDaemon.HassModel.CodeGenerator.Helpers
             {
                 HaName = field.Field!,
                 Type = type,
-                Required = field.Required == true
+                Required = field.Required == true,
+                Comment = field.Description + (string.IsNullOrWhiteSpace(field.Example?.ToString()) ? "" : $" eg: {field.Example}")
             };
         }
         private static Type GetTypeFromSelector(object? selectorObject)

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/ServiceArguments.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/ServiceArguments.cs
@@ -25,6 +25,8 @@ namespace NetDaemon.HassModel.CodeGenerator
         public string? VariableName => HaName?.ToNormalizedCamelCase();
 
         public string? ParameterVariableName => Required ? VariableName : $"{VariableName} = null";
+
+        public string? Comment { get; init; }
     }
 
     internal class ServiceArguments


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add xml comments to the generated code
This will show the documentation from HA in intellisense
- Summary description for Service methods
- Parameter description for arguments to service methods
- Friendly_name for Entities

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs