### PR TITLE
Fix NumberEntity generated as NumericNumberEntity

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/EntitySet.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/EntitySet.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using JoySoftware.HomeAssistant.Model;
 using NetDaemon.HassModel.CodeGenerator.Extensions;
 using NetDaemon.HassModel.CodeGenerator.Helpers;
@@ -7,7 +8,7 @@ namespace NetDaemon.HassModel.CodeGenerator
 {
     internal record EntitySet(string Domain, bool IsNumeric, IEnumerable<HassState> EntityStates)
     {
-        private readonly string prefixedDomain = (IsNumeric && Domain != "input_number" ? "numeric_" : "") + Domain;
+        private readonly string prefixedDomain = (IsNumeric && EntityIdHelper.MixedDomains.Contains(Domain)  ? "numeric_" : "") + Domain;
 
         public string EntityClassName => NamingHelper.GetDomainEntityTypeName(prefixedDomain);
 

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.Entitites.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Generator.Entitites.cs
@@ -167,8 +167,11 @@ namespace NetDaemon.HassModel.CodeGenerator
 
         private static bool IsNumeric(HassState entity)
         {
-            if (EntityIdHelper.GetDomain(entity.EntityId) == "input_number") return true; 
-            return entity.Attributes?.ContainsKey("unit_of_measurement") ?? false;
+            var domain = EntityIdHelper.GetDomain(entity.EntityId);
+            if (EntityIdHelper.NumericDomains.Contains(domain)) return true;
+
+            // Mixed domains have both numeric and non-numeric entities, if it has a 'unit_of_measurement' we threat it as numeric
+            return EntityIdHelper.MixedDomains.Contains(domain) && entity.Attributes?.ContainsKey("unit_of_measurement") == true;
         }
 
         /// <summary>

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/EntityIdHelper.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/EntityIdHelper.cs
@@ -4,6 +4,9 @@ namespace NetDaemon.HassModel.CodeGenerator.Helpers
 {
     internal static class EntityIdHelper
     {
+        public static readonly string[] NumericDomains = { "input_number", "number" };
+        public static readonly string[] MixedDomains = { "sensor" };
+        
         public static string GetDomain(string str)
         {
             return str[..str.IndexOf(".", StringComparison.InvariantCultureIgnoreCase)];

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
@@ -92,7 +92,7 @@ public class Root
     public void Run(IHaContext ha)
     {
         IEntities entities = new Entities(ha);
-        NumericSensor livingBass  = entities.Number.LivingBass;
+        NumberEntity livingBass  = entities.Number.LivingBass;
         double? bass = livingBass.State;
 
         InputNumberEntity targetTempEntity = entities.InputNumber.TargetTemperature;
@@ -111,9 +111,17 @@ public class Root
         [Fact]
         public void TestNumberExtensionMethodGeneration()
         {
-            var entityStates = new HassState[] { new() {
+            var entityStates = new HassState[] { 
+                new() {
                     EntityId = "number.living_bass",
                     AttributesJson = new { unit_of_measurement = "%", }.AsJsonElement()
+                },           
+                new() {
+                    EntityId = "unknown.number",
+                    AttributesJson = new { unit_of_measurement = "pcs", }.AsJsonElement()
+                },           
+                new() {
+                    EntityId = "unknown.string",
                 },           
             };
 
@@ -129,7 +137,6 @@ public class Root
                             Fields = new HassServiceField[] {
                                 new() { Field = "value", Selector = new NumberSelector(), },
                             },
-                            
                         }
                     }
                 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
@@ -58,24 +58,22 @@ public class Root
         [Fact]
         public void TestNumericSensorEntityGeneration()
         {
-            // NUmeric entities should be generated for input_numbers and sensors with a unit_of_measurement attribute
+            // Numeric entities should be generated for input_numbers and sensors with a unit_of_measurement attribute
             var entityStates = new HassState[]
             {
+                new() {
+                    EntityId = "number.living_bass",
+                    AttributesJson = new { unit_of_measurement = "%", }.AsJsonElement()
+                },           
                 new()
                 {
                     EntityId = "input_number.target_temperature",
-                    AttributesJson = new 
-                    {
-                        unit_of_measurement = "Kwh",
-                    }.AsJsonElement()
+                    AttributesJson = new { unit_of_measurement = "Kwh", }.AsJsonElement()
                 },                
                 new()
                 {
                     EntityId = "sensor.daily_power_consumption",
-                    AttributesJson = new 
-                    {
-                        unit_of_measurement = "Kwh",
-                    }.AsJsonElement()
+                    AttributesJson = new { unit_of_measurement = "Kwh", }.AsJsonElement()
                 },
                 new()
                 {
@@ -94,14 +92,62 @@ public class Root
     public void Run(IHaContext ha)
     {
         IEntities entities = new Entities(ha);
+        NumericSensor livingBass  = entities.Number.LivingBass;
+        double? bass = livingBass.State;
+
+        InputNumberEntity targetTempEntity = entities.InputNumber.TargetTemperature;
+        double? targetTempValue = targetTempEntity.State;
+
         NumericSensorEntity dailyPower = entities.Sensor.DailyPowerConsumption;
         double? cost = dailyPower.State;
 
         SensorEntity pirSensor = entities.Sensor.Pir;
         string? pir = pirSensor.State;
+     }
+}";
+            AssertCodeCompiles(generatedCode.ToString(), appCode);
+        }
         
-        InputNumberEntity targetTempEntity = entities.InputNumber.TargetTemperature;
-        double? targetTempValue = targetTempEntity.State;
+        [Fact]
+        public void TestNumberExtensionMethodGeneration()
+        {
+            var entityStates = new HassState[] { new() {
+                    EntityId = "number.living_bass",
+                    AttributesJson = new { unit_of_measurement = "%", }.AsJsonElement()
+                },           
+            };
+
+            var hassServiceDomains = new HassServiceDomain[] {
+                new() {
+                    Domain = "number",
+                    Services = new HassService[] {
+                        new() {
+                            Service = "set_value",
+                            Target = new TargetSelector {
+                                Entity = new() { Domain = "number" }
+                            },
+                            Fields = new HassServiceField[] {
+                                new() { Field = "value", Selector = new NumberSelector(), },
+                            },
+                            
+                        }
+                    }
+                }
+            };
+            
+            var generatedCode = Generator.CreateCompilationUnitSyntax("RootNameSpace", entityStates, hassServiceDomains);
+            var appCode = @"
+using NetDaemon.HassModel.Entities;
+using NetDaemon.HassModel.Common;
+using RootNameSpace;
+
+public class Root
+{
+    public void Run(IHaContext ha)
+    {
+        IEntities entities = new Entities(ha);
+
+    entities.Number.LivingBass.SetValue(12);
      }
 }";
             AssertCodeCompiles(generatedCode.ToString(), appCode);
@@ -166,36 +212,18 @@ public class Root
                 new()
                 {
                     Domain = "light",
-                    Services = new HassService[]
-                    {
-                        new()
-                        {
+                    Services = new HassService[] {
+                        new() {
                             Service = "turn_off",
-                            Target = new TargetSelector()
-                            {
-                                Entity = new() { Domain = "light" }
-                            }
+                            Target = new TargetSelector { Entity = new() { Domain = "light" } }
                         },
-                        new()
-                        {
+                        new() {
                             Service = "turn_on",
-                            Fields = new HassServiceField[]
-                            {
-                                new()
-                                {
-                                    Field = "transition",
-                                    Selector = new NumberSelector(),
-                                },
-                                new()
-                                {
-                                    Field = "brightness",
-                                    Selector = new NumberSelector { Step = 0.2f },
-                                }
+                            Fields = new HassServiceField[] {
+                                new() { Field = "transition", Selector = new NumberSelector(), },
+                                new() { Field = "brightness", Selector = new NumberSelector { Step = 0.2f }, }
                             },
-                            Target = new TargetSelector()
-                            {
-                                Entity = new() { Domain = "light" }
-                            }
+                            Target = new TargetSelector { Entity = new() { Domain = "light" } }
                         }
                     }
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The generated code will now only create Numeric Entity classes for  `input_number` and `number` entities and `sensors` that have a unit_of_measurement.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixed a problem where `Number entity classes  `were generated as 'NumericNumberEntity' while the extension method expects a NumberEntity parameter

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs