### PR TITLE
Automatically remove unused app state input booleans

### DIFF
--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
@@ -16,8 +16,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -42,8 +45,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -68,8 +74,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
 
@@ -98,8 +107,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
 
@@ -126,8 +138,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
 
@@ -156,8 +171,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
 
@@ -183,8 +201,11 @@ public class AppStateManagerTests
     {
         // ARRANGE
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
-            .AddTransient(_ => haConnectionMock.Object)
+            .AddSingleton(haRunnerMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -207,15 +228,19 @@ public class AppStateManagerTests
     }
 
     [Fact]
-    public void TestInitialize()
+    public async Task TestInitialize()
     {
         // ARRANGE
         var haContextMock = new Mock<IHaContext>();
         var appModelContextMock = new Mock<IAppModelContext>();
+        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
             .AddScoped(_ => haContextMock.Object)
-            .AddTransient(_ => haConnectionMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -226,22 +251,27 @@ public class AppStateManagerTests
         haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
 
         // ACT
-        homeAssistantStateUpdater.Initialize(haConnectionMock.Object, appModelContextMock.Object);
+        await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object)
+            .ConfigureAwait(false);
         // ASSERT
         hassEvent.HasObservers.Should().BeTrue();
     }
 
     [Fact]
-    public void TestAppDisabledShouldCallSetStateAsyncEnabled()
+    public async Task TestAppDisabledShouldCallSetStateAsyncEnabled()
     {
         // ARRANGE
         var haContextMock = new Mock<IHaContext>();
         var appModelContextMock = new Mock<IAppModelContext>();
+        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
         var appMock = new Mock<IApplication>();
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
             .AddScoped(_ => haContextMock.Object)
-            .AddTransient(_ => haConnectionMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -258,7 +288,9 @@ public class AppStateManagerTests
             });
 
         // ACT
-        homeAssistantStateUpdater.Initialize(haConnectionMock.Object, appModelContextMock.Object);
+        await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object)
+            .ConfigureAwait(false);
+
         hassEvent.OnNext(new HassEvent
         {
             EventType = "state_changed",
@@ -282,16 +314,20 @@ public class AppStateManagerTests
     }
 
     [Fact]
-    public void TestAppNoChangeShouldNotCallSetStateAsync()
+    public async Task TestAppNoChangeShouldNotCallSetStateAsync()
     {
         // ARRANGE
         var haContextMock = new Mock<IHaContext>();
         var appModelContextMock = new Mock<IAppModelContext>();
+        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
         var appMock = new Mock<IApplication>();
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
             .AddScoped(_ => haContextMock.Object)
-            .AddTransient(_ => haConnectionMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -308,7 +344,9 @@ public class AppStateManagerTests
             });
 
         // ACT
-        homeAssistantStateUpdater.Initialize(haConnectionMock.Object, appModelContextMock.Object);
+        await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object)
+            .ConfigureAwait(false);
+
         hassEvent.OnNext(new HassEvent
         {
             EventType = "state_changed",
@@ -333,16 +371,20 @@ public class AppStateManagerTests
     }
 
     [Fact]
-    public void TestAppOneStateIsNullShouldNotCallSetStateAsync()
+    public async Task TestAppOneStateIsNullShouldNotCallSetStateAsync()
     {
         // ARRANGE
         var haContextMock = new Mock<IHaContext>();
         var appModelContextMock = new Mock<IAppModelContext>();
+        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
         var appMock = new Mock<IApplication>();
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
         var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
             .AddScoped(_ => haContextMock.Object)
-            .AddTransient(_ => haConnectionMock.Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -359,7 +401,7 @@ public class AppStateManagerTests
             });
 
         // ACT
-        homeAssistantStateUpdater.Initialize(haConnectionMock.Object, appModelContextMock.Object);
+        await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object);
         hassEvent.OnNext(new HassEvent
         {
             EventType = "state_changed",
@@ -376,22 +418,5 @@ public class AppStateManagerTests
 
         // ASSERT
         appMock.Verify(n => n.SetStateAsync(ApplicationState.Disabled), Times.Never);
-    }
-
-    [Theory]
-    [InlineData("lowercase", "lowercase")]
-    [InlineData("lower.namespace.lowercase", "lower_namespace_lowercase")]
-    [InlineData("Namespace.Class", "namespace_class")]
-    [InlineData("Namespace.ClassNameWithUpperAndLower", "namespace_class_name_with_upper_and_lower")]
-    [InlineData("ALLUPPERCASE", "alluppercase")]
-    [InlineData("DIClass", "diclass")]
-    [InlineData("DiClass", "di_class")]
-    [InlineData("Di_Class", "di_class")]
-    [InlineData("di_class", "di_class")]
-    [InlineData("di__class", "di_class")]
-    public void TestToSafeHomeAssistantEntityIdFromApplicationIdShouldGiveCorrectName(string fromId, string toId)
-    {
-        var expected = $"input_boolean.netdaemon_{toId}";
-        AppStateManager.ToSafeHomeAssistantEntityIdFromApplicationId(fromId).Should().Be(expected);
     }
 }

--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateRepositoryTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateRepositoryTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Net;
+using NetDaemon.Client.Internal.Exceptions;
+using NetDaemon.Runtime.Internal;
+using NetDaemon.Runtime.Internal.Model;
+
+namespace NetDaemon.Runtime.Tests.Internal;
+
+public class AppStateRepositoryTests
+{
+    private readonly Mock<IHomeAssistantConnection> _connectionMock = new();
+    private readonly AppStateRepository _repository;
+    private readonly Mock<IHomeAssistantRunner> _runnerMock = new();
+
+    public AppStateRepositoryTests()
+    {
+        _runnerMock.SetupGet(x => x.CurrentConnection).Returns(_connectionMock.Object);
+        _repository = new AppStateRepository(_runnerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsyncShouldSendCreateInputBooleanCommandIfEntityNotExists()
+    {
+        _connectionMock
+            .Setup(n => n.GetApiCallAsync<HassState>("states/input_boolean.netdaemon_some_app_id",
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HomeAssistantApiCallException("", HttpStatusCode.NotFound));
+
+        var result = await _repository.GetOrCreateAsync("some_app_id", CancellationToken.None);
+
+        _connectionMock.Verify(
+            n => n.SendCommandAndReturnResponseAsync<CreateInputBooleanHelperCommand, InputBooleanHelper>(
+                It.IsAny<CreateInputBooleanHelperCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsyncShouldNotSendCreateInputBooleanCommandIfEntityExists()
+    {
+        _connectionMock
+            .Setup(n => n.GetApiCallAsync<HassState>("states/input_boolean.netdaemon_some_app_id",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HassState
+            {
+                EntityId = "input_boolean.netdaemon_some_app_id",
+                State = "on"
+            });
+
+        _ = await _repository.GetOrCreateAsync("some_app_id", CancellationToken.None);
+        _connectionMock.Verify(
+            n => n.SendCommandAndReturnResponseAsync<CreateInputBooleanHelperCommand, InputBooleanHelper>(
+                It.IsAny<CreateInputBooleanHelperCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("on", true)]
+    [InlineData("off", false)]
+    public async Task GetOrCreateAsyncShouldReturnCorrectEnabledStateForAppDependingOnStateOfInputBooleanHelper(
+        string entityState, bool isEnabled)
+    {
+        _connectionMock
+            .Setup(n => n.GetApiCallAsync<HassState>("states/input_boolean.netdaemon_some_app_id",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HassState
+            {
+                EntityId = "input_boolean.netdaemon_some_app_id",
+                State = entityState
+            });
+
+
+        var result = await _repository.GetOrCreateAsync("some_app_id", CancellationToken.None);
+
+        result.Should().Be(isEnabled);
+    }
+
+    [Fact]
+    public async Task RemoveNotUsedStatesAsyncShouldRemoveEntitiesThatDoesNotCorrespondToAnAppId()
+    {
+        var resultList = new[]
+        {
+            new InputBooleanHelper {Id = "netdaemon_some_app_id", Name = "netdaemon_some_app_id"},
+            new InputBooleanHelper {Id = "netdaemon_some_app_id2", Name = "netdaemon_some_app_id2"}
+        };
+        _connectionMock.Setup(n =>
+            n.SendCommandAndReturnResponseAsync<ListInputBooleanHelperCommand,
+                IReadOnlyCollection<InputBooleanHelper>>(It.IsAny<ListInputBooleanHelperCommand>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(resultList.ToList());
+
+        var applicationIds = new[] {"some_app_id"};
+        await _repository.RemoveNotUsedStatesAsync(applicationIds, CancellationToken.None);
+
+        // var command = new DeleteInputBooleanHelperCommand() {InputBooleanId = "some_app_id2", Type = "input_boolean/list""};
+        _connectionMock.Verify(
+            n => n.SendCommandAndReturnResponseAsync<DeleteInputBooleanHelperCommand, object?>(
+                It.Is<DeleteInputBooleanHelperCommand>(n => n.InputBooleanId == "netdaemon_some_app_id2"),
+                It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveNotUsedStatesAsyncShouldNotRemoveNonNetDaemonInputBooleans()
+    {
+        var resultList = new[]
+        {
+            new InputBooleanHelper {Id = "netdaemon_some_app_id", Name = "netdaemon_some_app_id"},
+            new InputBooleanHelper {Id = "netdaemon_some_app_id2", Name = "netdaemon_some_app_id2"},
+            new InputBooleanHelper {Id = "non_netdaemon_input_boolean", Name = "non_netdaemon_input_boolean"}
+        };
+        _connectionMock.Setup(n =>
+            n.SendCommandAndReturnResponseAsync<ListInputBooleanHelperCommand,
+                IReadOnlyCollection<InputBooleanHelper>>(It.IsAny<ListInputBooleanHelperCommand>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(resultList.ToList());
+
+        var applicationIds = new[] {"some_app_id"};
+        await _repository.RemoveNotUsedStatesAsync(applicationIds, CancellationToken.None);
+
+        // var command = new DeleteInputBooleanHelperCommand() {InputBooleanId = "some_app_id2", Type = "input_boolean/list""};
+        _connectionMock.Verify(
+            n => n.SendCommandAndReturnResponseAsync<DeleteInputBooleanHelperCommand, object?>(
+                It.Is<DeleteInputBooleanHelperCommand>(n => n.InputBooleanId == "non_netdaemon_input_boolean"),
+                It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/EntityMapperHelperTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/EntityMapperHelperTests.cs
@@ -1,0 +1,23 @@
+﻿using NetDaemon.Runtime.Internal;
+
+namespace NetDaemon.Runtime.Tests.Internal;
+
+public class EntityMapperHelperTests
+{
+    [Theory]
+    [InlineData("lowercase", "lowercase")]
+    [InlineData("lower.namespace.lowercase", "lower_namespace_lowercase")]
+    [InlineData("Namespace.Class", "namespace_class")]
+    [InlineData("Namespace.ClassNameWithUpperAndLower", "namespace_class_name_with_upper_and_lower")]
+    [InlineData("ALLUPPERCASE", "alluppercase")]
+    [InlineData("DIClass", "diclass")]
+    [InlineData("DiClass", "di_class")]
+    [InlineData("Di_Class", "di_class")]
+    [InlineData("di_class", "di_class")]
+    [InlineData("di__class", "di_class")]
+    public void TestToSafeHomeAssistantEntityIdFromApplicationIdShouldGiveCorrectName(string fromId, string toId)
+    {
+        var expected = $"input_boolean.netdaemon_{toId}";
+        EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId(fromId).Should().Be(expected);
+    }
+}

--- a/src/Runtime/NetDaemon.Runtime/Common/Extensions/ServiceBuilderExtensions.cs
+++ b/src/Runtime/NetDaemon.Runtime/Common/Extensions/ServiceBuilderExtensions.cs
@@ -10,7 +10,8 @@ public static class ServiceBuilderExtensions
         services.AddSingleton<AppStateManager>();
         services.AddSingleton<IAppStateManager>(s => s.GetRequiredService<AppStateManager>());
         services.AddSingleton<IHandleHomeAssistantAppStateUpdates>(s => s.GetRequiredService<AppStateManager>());
-
+        services.AddSingleton<AppStateRepository>();
+        services.AddSingleton<IAppStateRepository>(s => s.GetRequiredService<AppStateRepository>());
         return services;
     }
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
@@ -1,67 +1,61 @@
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Net;
 using System.Reactive.Linq;
-using System.Text;
 using NetDaemon.AppModel;
-using NetDaemon.Client.HomeAssistant.Model;
-using NetDaemon.Client.Internal.Exceptions;
 
 namespace NetDaemon.Runtime.Internal;
 
 internal class AppStateManager : IAppStateManager, IHandleHomeAssistantAppStateUpdates, IDisposable
 {
+    private readonly IAppStateRepository _appStateRepository;
     private readonly CancellationTokenSource _cancelTokenSource = new();
-    private readonly IServiceProvider _provider;
     private readonly ConcurrentDictionary<string, ApplicationState> _stateCache = new();
 
     public AppStateManager(
-        IServiceProvider provider
+        IAppStateRepository appStateRepository
     )
     {
-        _provider = provider;
+        _appStateRepository = appStateRepository;
     }
 
     public async Task<ApplicationState> GetStateAsync(string applicationId)
     {
-        var entityId = ToSafeHomeAssistantEntityIdFromApplicationId(applicationId);
-        if (_stateCache.TryGetValue(entityId, out var applicationState)) return applicationState;
+        if (_stateCache.TryGetValue(applicationId, out var applicationState)) return applicationState;
 
-        return (await GetOrCreateStateForApp(entityId).ConfigureAwait(false))?.State == "on"
+        return await _appStateRepository.GetOrCreateAsync(applicationId, _cancelTokenSource.Token)
+            .ConfigureAwait(false)
             ? ApplicationState.Enabled
             : ApplicationState.Disabled;
     }
 
     public async Task SaveStateAsync(string applicationId, ApplicationState state)
     {
-        var haConnection = _provider.GetRequiredService<IHomeAssistantConnection>() ??
-                           throw new InvalidOperationException();
-        var entityId = ToSafeHomeAssistantEntityIdFromApplicationId(applicationId);
+        _stateCache[applicationId] = state;
 
-        _stateCache[entityId] = state;
-
-        var currentState = (await GetOrCreateStateForApp(entityId).ConfigureAwait(false))?.State
-                           ?? throw new InvalidOperationException();
+        var isEnabled = await _appStateRepository.GetOrCreateAsync(applicationId, _cancelTokenSource.Token)
+            .ConfigureAwait(false);
 
         switch (state)
         {
-            case ApplicationState.Enabled when currentState == "off":
-                await haConnection.CallServiceAsync("input_boolean", "turn_on",
-                    new HassTarget {EntityIds = new[] {entityId}},
-                    cancelToken: _cancelTokenSource.Token);
-                break;
-            case ApplicationState.Disabled when currentState == "on":
-                await haConnection.CallServiceAsync("input_boolean", "turn_off",
-                    new HassTarget {EntityIds = new[] {entityId}},
-                    cancelToken: _cancelTokenSource.Token);
+            case ApplicationState.Enabled when !isEnabled:
+            case ApplicationState.Disabled when isEnabled:
+                await _appStateRepository.UpdateAsync(applicationId, isEnabled, _cancelTokenSource.Token)
+                    .ConfigureAwait(false);
                 break;
         }
     }
 
-    public void Initialize(IHomeAssistantConnection haConnection, IAppModelContext appContext)
+    public void Dispose()
     {
-        ClearExistingCacheOnNewConnection();
+        _cancelTokenSource.Dispose();
+    }
+
+    public async Task InitializeAsync(IHomeAssistantConnection haConnection, IAppModelContext appContext)
+    {
+        _stateCache.Clear();
+        if (appContext.Applications.Count > 0)
+            await _appStateRepository.RemoveNotUsedStatesAsync(appContext.Applications.Select(a => a.Id).ToList()!,
+                _cancelTokenSource.Token);
+
         haConnection.OnHomeAssistantEvent
             .Where(n => n.EventType == "state_changed")
             .Select(async s =>
@@ -77,7 +71,8 @@ internal class AppStateManager : IAppStateManager, IHandleHomeAssistantAppStateU
                 foreach (var app in appContext.Applications)
                 {
                     var entityId =
-                        ToSafeHomeAssistantEntityIdFromApplicationId(app.Id ?? throw new InvalidOperationException());
+                        EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId(app.Id ??
+                            throw new InvalidOperationException());
                     if (entityId != changedEvent.NewState.EntityId) continue;
 
                     var appState = changedEvent.NewState?.State == "on"
@@ -90,86 +85,5 @@ internal class AppStateManager : IAppStateManager, IHandleHomeAssistantAppStateU
                     break;
                 }
             }).Subscribe();
-    }
-
-
-    /// <summary>
-    ///     Converts any unicode string to a safe Home Assistant name
-    /// </summary>
-    /// <param name="applicationId">The unicode string to convert</param>
-    [SuppressMessage("Microsoft.Globalization", "CA1308")]
-    [SuppressMessage("", "CA1062")]
-    public static string ToSafeHomeAssistantEntityIdFromApplicationId(string applicationId)
-    {
-        var normalizedString = applicationId.Normalize(NormalizationForm.FormD);
-        StringBuilder stringBuilder = new(applicationId.Length);
-
-        char lastChar = '\0';
-
-        foreach (var c in normalizedString)
-        {
-            switch (CharUnicodeInfo.GetUnicodeCategory(c))
-            {
-                case UnicodeCategory.LowercaseLetter:
-                    stringBuilder.Append(c);
-                    break;
-                case UnicodeCategory.UppercaseLetter:
-                    if (CharUnicodeInfo.GetUnicodeCategory(lastChar) == UnicodeCategory.LowercaseLetter)
-                    {
-                        if (lastChar != '_')
-                            stringBuilder.Append('_');
-                    }
-                    stringBuilder.Append(char.ToLowerInvariant(c));
-                    break;
-                case UnicodeCategory.DecimalDigitNumber:
-                    stringBuilder.Append(c);
-                    break;
-                case UnicodeCategory.SpaceSeparator:
-                case UnicodeCategory.ConnectorPunctuation:
-                case UnicodeCategory.DashPunctuation:
-                case UnicodeCategory.OtherPunctuation:
-                    if (lastChar != '_')
-                        stringBuilder.Append('_');
-                    break;
-            }
-           lastChar = c;
-        }
-
-        return $"input_boolean.netdaemon_{stringBuilder.ToString().ToLowerInvariant()}";
-    }
-
-    private void ClearExistingCacheOnNewConnection()
-    {
-        _stateCache.Clear();
-    }
-
-    private async Task<HassState?> GetOrCreateStateForApp(string entityId)
-    {
-        var haConnection = _provider.GetRequiredService<IHomeAssistantConnection>();
-
-        try
-        {
-            var state = await haConnection.GetEntityStateAsync(entityId, _cancelTokenSource.Token)
-                .ConfigureAwait(false);
-            return state;
-        }
-        catch (HomeAssistantApiCallException e)
-        {
-            // Missing entity will throw a http status not found
-            if (e.Code != HttpStatusCode.NotFound) throw;
-            // The app state input_boolean does not exist, lets create a helper
-            var name = entityId[14..]; // remove the "input_boolean." part
-            await haConnection.CreateInputBooleanHelperAsync(name, _cancelTokenSource.Token);
-            _stateCache[entityId] = ApplicationState.Enabled;
-            await haConnection.CallServiceAsync("input_boolean", "turn_on",
-                new HassTarget {EntityIds = new[] {entityId}},
-                cancelToken: _cancelTokenSource.Token).ConfigureAwait(false);
-            return new HassState {State = "on"};
-        }
-    }
-
-    public void Dispose()
-    {
-        _cancelTokenSource.Dispose();
     }
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
@@ -52,9 +52,6 @@ internal class AppStateRepository : IAppStateRepository
 
     public async Task RemoveNotUsedStatesAsync(IReadOnlyCollection<string> applicationIds, CancellationToken token)
     {
-        if (applicationIds.Count == 0)
-            return;
-
         var haConnection = _runner.CurrentConnection ??
                            throw new InvalidOperationException();
         var helpers = await haConnection.ListInputBooleanHelpersAsync(token).ConfigureAwait(false);

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
@@ -56,7 +56,8 @@ internal class AppStateRepository : IAppStateRepository
                            throw new InvalidOperationException();
         var helpers = await haConnection.ListInputBooleanHelpersAsync(token).ConfigureAwait(false);
 
-        var entityIds = applicationIds.Select(EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId);
+        var entityIds = applicationIds.Select(EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId)
+            .ToHashSet();
 
         var notUsedHelperIds = helpers.Where(n =>
             !entityIds.Contains($"input_boolean.{n.Name}") && n.Id.StartsWith("netdaemon_"));

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateRepository.cs
@@ -1,0 +1,70 @@
+﻿using System.Net;
+using NetDaemon.Client.HomeAssistant.Model;
+using NetDaemon.Client.Internal.Exceptions;
+
+namespace NetDaemon.Runtime.Internal;
+
+internal class AppStateRepository : IAppStateRepository
+{
+    private readonly IHomeAssistantRunner _runner;
+
+    public AppStateRepository(IHomeAssistantRunner runner)
+    {
+        _runner = runner;
+    }
+
+    public async Task<bool> GetOrCreateAsync(string applicationId, CancellationToken token)
+    {
+        var haConnection = _runner.CurrentConnection ??
+                           throw new InvalidOperationException();
+
+        var entityId = EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId(applicationId);
+
+        try
+        {
+            var state = await haConnection.GetEntityStateAsync(entityId, token)
+                .ConfigureAwait(false);
+            return state?.State == "on";
+        }
+        catch (HomeAssistantApiCallException e)
+        {
+            // Missing entity will throw a http status not found
+            if (e.Code != HttpStatusCode.NotFound) throw;
+            // The app state input_boolean does not exist, lets create a helper
+            var name = entityId[14..]; // remove the "input_boolean." part
+            await haConnection.CreateInputBooleanHelperAsync(name, token);
+            await UpdateAsync(applicationId, true, token);
+            return true;
+        }
+    }
+
+    public async Task UpdateAsync(string applicationId, bool enabled, CancellationToken token)
+    {
+        var haConnection = _runner.CurrentConnection ??
+                           throw new InvalidOperationException();
+
+        var entityId = EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId(applicationId);
+
+        await haConnection.CallServiceAsync("input_boolean", enabled ? "turn_on" : "turn_off",
+            new HassTarget {EntityIds = new[] {entityId}},
+            cancelToken: token).ConfigureAwait(false);
+    }
+
+    public async Task RemoveNotUsedStatesAsync(IReadOnlyCollection<string> applicationIds, CancellationToken token)
+    {
+        if (applicationIds.Count == 0)
+            return;
+
+        var haConnection = _runner.CurrentConnection ??
+                           throw new InvalidOperationException();
+        var helpers = await haConnection.ListInputBooleanHelpersAsync(token).ConfigureAwait(false);
+
+        var entityIds = applicationIds.Select(EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId);
+
+        var notUsedHelperIds = helpers.Where(n =>
+            !entityIds.Contains($"input_boolean.{n.Name}") && n.Id.StartsWith("netdaemon_"));
+
+        foreach (var helper in notUsedHelperIds)
+            await haConnection.DeleteInputBooleanHelperAsync(helper.Id, token).ConfigureAwait(false);
+    }
+}

--- a/src/Runtime/NetDaemon.Runtime/Internal/EntityMapperHelper.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/EntityMapperHelper.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+
+namespace NetDaemon.Runtime.Internal;
+
+public static class EntityMapperHelper
+{
+    /// <summary>
+    ///     Converts any unicode string to a safe Home Assistant name for the helper
+    /// </summary>
+    /// <param name="applicationId">The unicode string to convert</param>
+    [SuppressMessage("Microsoft.Globalization", "CA1308")]
+    [SuppressMessage("", "CA1062")]
+    public static string ToSafeHomeAssistantEntityIdFromApplicationId(string applicationId)
+    {
+        var normalizedString = applicationId.Normalize(NormalizationForm.FormD);
+        StringBuilder stringBuilder = new(applicationId.Length);
+
+        var lastChar = '\0';
+
+        foreach (var c in normalizedString)
+        {
+            switch (CharUnicodeInfo.GetUnicodeCategory(c))
+            {
+                case UnicodeCategory.LowercaseLetter:
+                    stringBuilder.Append(c);
+                    break;
+                case UnicodeCategory.UppercaseLetter:
+                    if (CharUnicodeInfo.GetUnicodeCategory(lastChar) == UnicodeCategory.LowercaseLetter)
+                        if (lastChar != '_')
+                            stringBuilder.Append('_');
+                    stringBuilder.Append(char.ToLowerInvariant(c));
+                    break;
+                case UnicodeCategory.DecimalDigitNumber:
+                    stringBuilder.Append(c);
+                    break;
+                case UnicodeCategory.SpaceSeparator:
+                case UnicodeCategory.ConnectorPunctuation:
+                case UnicodeCategory.DashPunctuation:
+                case UnicodeCategory.OtherPunctuation:
+                    if (lastChar != '_')
+                        stringBuilder.Append('_');
+                    break;
+            }
+
+            lastChar = c;
+        }
+
+        return $"input_boolean.netdaemon_{stringBuilder.ToString().ToLowerInvariant()}";
+    }
+}

--- a/src/Runtime/NetDaemon.Runtime/Internal/HomeAssistantConnectionExtensions.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/HomeAssistantConnectionExtensions.cs
@@ -12,6 +12,24 @@ internal static class HomeAssistantConnectionExtensions
             new CreateInputBooleanHelperCommand
             {
                 Name = name
-            }, cancelToken);
+            }, cancelToken).ConfigureAwait(false);
+    }
+
+    public static async Task DeleteInputBooleanHelperAsync(
+        this IHomeAssistantConnection connection,
+        string inputBooleanId, CancellationToken cancelToken)
+    {
+        await connection.SendCommandAndReturnResponseAsync<DeleteInputBooleanHelperCommand, object?>(
+            new DeleteInputBooleanHelperCommand
+            {
+                InputBooleanId = inputBooleanId
+            }, cancelToken).ConfigureAwait(false);
+    }
+
+    public static async Task<IReadOnlyCollection< InputBooleanHelper>> ListInputBooleanHelpersAsync(
+        this IHomeAssistantConnection connection, CancellationToken cancelToken)
+    {
+        return await connection.SendCommandAndReturnResponseAsync<ListInputBooleanHelperCommand, IReadOnlyCollection< InputBooleanHelper>>(
+            new ListInputBooleanHelperCommand(), cancelToken) ?? Array.Empty<InputBooleanHelper>();
     }
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/IAppStateRepository.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/IAppStateRepository.cs
@@ -1,0 +1,8 @@
+﻿namespace NetDaemon.Runtime.Internal;
+
+internal interface IAppStateRepository
+{
+    Task<bool> GetOrCreateAsync(string applicationId, CancellationToken token);
+    Task UpdateAsync(string applicationId, bool enabled, CancellationToken token);
+    Task RemoveNotUsedStatesAsync(IReadOnlyCollection<string> applicationIds, CancellationToken token);
+}

--- a/src/Runtime/NetDaemon.Runtime/Internal/IHandleHomeAssistantAppStateUpdates.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/IHandleHomeAssistantAppStateUpdates.cs
@@ -4,5 +4,5 @@ namespace NetDaemon.Runtime.Internal;
 
 internal interface IHandleHomeAssistantAppStateUpdates
 {
-    void Initialize(IHomeAssistantConnection haConnection, IAppModelContext appContext);
+    Task InitializeAsync(IHomeAssistantConnection haConnection, IAppModelContext appContext);
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/Model/CreateInputBooleanHelperCommand.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/Model/CreateInputBooleanHelperCommand.cs
@@ -12,3 +12,21 @@ internal record CreateInputBooleanHelperCommand : CommandMessage
 
     [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
 }
+
+internal record DeleteInputBooleanHelperCommand : CommandMessage
+{
+    public DeleteInputBooleanHelperCommand()
+    {
+        Type = "input_boolean/delete";
+    }
+
+    [JsonPropertyName("input_boolean_id")] public string InputBooleanId { get; init; } = string.Empty;
+}
+
+internal record ListInputBooleanHelperCommand : CommandMessage
+{
+    public ListInputBooleanHelperCommand()
+    {
+        Type = "input_boolean/list";
+    }
+}

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -97,12 +97,13 @@ internal class NetDaemonRuntime : IRuntime
 
             await _cacheManager.InitializeAsync(cancelToken).ConfigureAwait(false);
 
+
             _applicationModelContext =
                 await _appModel.InitializeAsync(CancellationToken.None).ConfigureAwait(false);
 
             // Handle state change for apps if registered
-            var appStateHandler = _serviceProvider.GetService<IHandleHomeAssistantAppStateUpdates>();
-            appStateHandler?.Initialize(haConnection, _applicationModelContext);
+            var appStateHandler = _serviceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+            await appStateHandler.InitializeAsync(haConnection, _applicationModelContext);
         }
         catch (Exception e)
         {

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -97,7 +97,6 @@ internal class NetDaemonRuntime : IRuntime
 
             await _cacheManager.InitializeAsync(cancelToken).ConfigureAwait(false);
 
-
             _applicationModelContext =
                 await _appModel.InitializeAsync(CancellationToken.None).ConfigureAwait(false);
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes unused input boolean helpers for non existing apps

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs