### PR TITLE
Adds specific naming rules for when is in development for input booleans app states

### DIFF
--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Reactive.Subjects;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NetDaemon.AppModel;
 using NetDaemon.Client.Internal.Exceptions;
 using NetDaemon.HassModel;
@@ -21,6 +22,7 @@ public class AppStateManagerTests
 
         var provider = new ServiceCollection()
             .AddSingleton(haRunnerMock.Object)
+            .AddSingleton(new Mock<IHostEnvironment>().Object)
             .AddNetDaemonStateManager()
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
@@ -44,17 +46,9 @@ public class AppStateManagerTests
     public async Task TestGetStateAsyncReturnsCorrectStateDisabled()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-        using var scopedProvider = provider.CreateScope();
-
-        var appStateManager = scopedProvider.ServiceProvider.GetRequiredService<IAppStateManager>();
+        var appStateManager = provider.GetRequiredService<IAppStateManager>();
 
         // ACT
         // ASSERT
@@ -73,16 +67,9 @@ public class AppStateManagerTests
     public async Task TestSaveStateAsyncReturnsCorrectStateDisabled()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+        var (haConnectionMock, scopedProvider) = SetupProviderAndMocks();
 
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-
-        var appStateManager = provider.GetRequiredService<IAppStateManager>();
+        var appStateManager = scopedProvider.GetRequiredService<IAppStateManager>();
         haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(
                 new HassState
@@ -106,14 +93,7 @@ public class AppStateManagerTests
     public async Task TestGetStateAsyncNotExistReturnsCorrectStateEnabled()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
-
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
         var appStateManager = provider.GetRequiredService<IAppStateManager>();
         haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -134,17 +114,34 @@ public class AppStateManagerTests
     }
 
     [Fact]
+    public async Task TestGetStateAsyncNotExistReturnsCorrectStateEnabledInDevelopment()
+    {
+        // ARRANGE
+        var (haConnectionMock, provider) = SetupProviderAndMocksDevelopment();
+
+        var appStateManager = provider.GetRequiredService<IAppStateManager>();
+        haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(
+                new HomeAssistantApiCallException("ohh no", HttpStatusCode.NotFound));
+        // ACT
+        _ = await appStateManager.GetStateAsync("helloapp");
+        // ASSERT
+        haConnectionMock.Verify(n =>
+            n.GetApiCallAsync<HassState>("states/input_boolean.dev_netdaemon_helloapp", It.IsAny<CancellationToken>()));
+        // It exists so it should turn it on
+        haConnectionMock.Verify(n =>
+            n.SendCommandAndReturnResponseAsync<CreateInputBooleanHelperCommand, InputBooleanHelper>(
+                It.IsAny<CreateInputBooleanHelperCommand>(), It.IsAny<CancellationToken>()));
+        haConnectionMock.Verify(n =>
+            n.SendCommandAndReturnResponseAsync<CallServiceCommand, object>(It.IsAny<CallServiceCommand>(),
+                It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
     public async Task TestSetStateAsyncEnabled()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
-
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
         var appStateManager = provider.GetRequiredService<IAppStateManager>();
         haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -170,14 +167,7 @@ public class AppStateManagerTests
     public async Task TestSetStateAsyncRunning()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
-
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
         var appStateManager = provider.GetRequiredService<IAppStateManager>();
         haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -200,17 +190,9 @@ public class AppStateManagerTests
     public async Task TestSetStateAsyncError()
     {
         // ARRANGE
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-        using var scopedProvider = provider.CreateScope();
-
-        var appStateManager = scopedProvider.ServiceProvider.GetRequiredService<IAppStateManager>();
+        var appStateManager = provider.GetRequiredService<IAppStateManager>();
 
         haConnectionMock.Setup(n => n.GetApiCallAsync<HassState>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -233,15 +215,22 @@ public class AppStateManagerTests
         // ARRANGE
         var haContextMock = new Mock<IHaContext>();
         var appModelContextMock = new Mock<IAppModelContext>();
-        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
+        appModelContextMock.SetupGet(n => n.Applications)
+            .Returns(new List<IApplication>() {new Mock<IApplication>().Object});
+
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
+
         var haRunnerMock = new Mock<IHomeAssistantRunner>();
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
+        var repositoryMock = new Mock<IAppStateRepository>();
 
         var provider = new ServiceCollection()
             .AddSingleton(haRunnerMock.Object)
             .AddScoped(_ => haContextMock.Object)
+            .AddSingleton(new Mock<IHostEnvironment>().Object)
             .AddNetDaemonStateManager()
+            .AddSingleton(repositoryMock.Object)
             .BuildServiceProvider();
         using var scopedProvider = provider.CreateScope();
 
@@ -255,29 +244,58 @@ public class AppStateManagerTests
             .ConfigureAwait(false);
         // ASSERT
         hassEvent.HasObservers.Should().BeTrue();
+        repositoryMock.Verify(n => n.RemoveNotUsedStatesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task InitializeShouldNeverTryDeleteUnusedInputBooleanHelpersWhenInDevelopmentEnvironment()
+    {
+        // ARRANGE
+        var haContextMock = new Mock<IHaContext>();
+        var appModelContextMock = new Mock<IAppModelContext>();
+        // Make sure we have at least one application for this scenario
+        appModelContextMock.SetupGet(n => n.Applications)
+            .Returns(new List<IApplication>(){new Mock<IApplication>().Object});
+        var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(new Subject<HassEvent>());
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
+        var environmentMock = new Mock<IHostEnvironment>();
+        environmentMock.Setup(n => n.EnvironmentName).Returns("Development");
+        var repositoryMock = new Mock<IAppStateRepository>();
+
+        var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
+            .AddScoped(_ => haContextMock.Object)
+            .AddSingleton(environmentMock.Object)
+            .AddNetDaemonStateManager()
+            .AddSingleton(repositoryMock.Object)
+            .BuildServiceProvider();
+        using var scopedProvider = provider.CreateScope();
+
+        var homeAssistantStateUpdater =
+            scopedProvider.ServiceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+
+        // ACT
+        await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object)
+            .ConfigureAwait(false);
+        // ASSERT
+        repositoryMock.Verify(n => n.RemoveNotUsedStatesAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+
     }
 
     [Fact]
     public async Task TestAppDisabledShouldCallSetStateAsyncEnabled()
     {
         // ARRANGE
-        var haContextMock = new Mock<IHaContext>();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
         var appModelContextMock = new Mock<IAppModelContext>();
         appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
         var appMock = new Mock<IApplication>();
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
-
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddScoped(_ => haContextMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-        using var scopedProvider = provider.CreateScope();
 
         var homeAssistantStateUpdater =
-            scopedProvider.ServiceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+            provider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
         Subject<HassEvent> hassEvent = new();
         haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
         appMock.SetupGet(n => n.Id).Returns("app");
@@ -317,24 +335,18 @@ public class AppStateManagerTests
     public async Task TestAppNoChangeShouldNotCallSetStateAsync()
     {
         // ARRANGE
-        var haContextMock = new Mock<IHaContext>();
-        var appModelContextMock = new Mock<IAppModelContext>();
-        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
-        var appMock = new Mock<IApplication>();
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        var haRunnerMock = new Mock<IHomeAssistantRunner>();
-        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
-
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddScoped(_ => haContextMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-        using var scopedProvider = provider.CreateScope();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
 
         var homeAssistantStateUpdater =
-            scopedProvider.ServiceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+            provider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+
         Subject<HassEvent> hassEvent = new();
+
+        var appModelContextMock = new Mock<IAppModelContext>();
+        appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
+
+        var appMock = new Mock<IApplication>();
+
         haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
         appMock.SetupGet(n => n.Id).Returns("app");
         appModelContextMock.SetupGet(n => n.Applications).Returns(
@@ -374,23 +386,19 @@ public class AppStateManagerTests
     public async Task TestAppOneStateIsNullShouldNotCallSetStateAsync()
     {
         // ARRANGE
-        var haContextMock = new Mock<IHaContext>();
+        var (haConnectionMock, provider) = SetupProviderAndMocks();
+
         var appModelContextMock = new Mock<IAppModelContext>();
         appModelContextMock.SetupGet(n => n.Applications).Returns(new List<IApplication>());
+
         var appMock = new Mock<IApplication>();
-        var haConnectionMock = new Mock<IHomeAssistantConnection>();
+
         var haRunnerMock = new Mock<IHomeAssistantRunner>();
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
 
-        var provider = new ServiceCollection()
-            .AddSingleton(haRunnerMock.Object)
-            .AddScoped(_ => haContextMock.Object)
-            .AddNetDaemonStateManager()
-            .BuildServiceProvider();
-        using var scopedProvider = provider.CreateScope();
 
         var homeAssistantStateUpdater =
-            scopedProvider.ServiceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+            provider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
         Subject<HassEvent> hassEvent = new();
         haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
         appMock.SetupGet(n => n.Id).Returns("app");
@@ -418,5 +426,38 @@ public class AppStateManagerTests
 
         // ASSERT
         appMock.Verify(n => n.SetStateAsync(ApplicationState.Disabled), Times.Never);
+    }
+
+    private (Mock<IHomeAssistantConnection> connection, IServiceProvider serviceProvider) SetupProviderAndMocks()
+    {
+        var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+
+        var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
+            .AddSingleton(new Mock<IHostEnvironment>().Object)
+            .AddNetDaemonStateManager()
+            .BuildServiceProvider();
+        var scopedProvider = provider.CreateScope();
+
+        return (haConnectionMock, scopedProvider.ServiceProvider);
+    }
+
+    private (Mock<IHomeAssistantConnection> connection, IServiceProvider serviceProvider) SetupProviderAndMocksDevelopment()
+    {
+        var haConnectionMock = new Mock<IHomeAssistantConnection>();
+        var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
+        var environmentMock = new Mock<IHostEnvironment>();
+        environmentMock.Setup(n => n.EnvironmentName).Returns("Development");
+        var provider = new ServiceCollection()
+            .AddSingleton(haRunnerMock.Object)
+            .AddSingleton(environmentMock.Object)
+            .AddNetDaemonStateManager()
+            .BuildServiceProvider();
+        var scopedProvider = provider.CreateScope();
+
+        return (haConnectionMock, scopedProvider.ServiceProvider);
     }
 }

--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/EntityMapperHelperTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/EntityMapperHelperTests.cs
@@ -18,6 +18,23 @@ public class EntityMapperHelperTests
     public void TestToSafeHomeAssistantEntityIdFromApplicationIdShouldGiveCorrectName(string fromId, string toId)
     {
         var expected = $"input_boolean.netdaemon_{toId}";
-        EntityMapperHelper.ToSafeHomeAssistantEntityIdFromApplicationId(fromId).Should().Be(expected);
+        EntityMapperHelper.ToEntityIdFromApplicationId(fromId).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("lowercase", "lowercase")]
+    [InlineData("lower.namespace.lowercase", "lower_namespace_lowercase")]
+    [InlineData("Namespace.Class", "namespace_class")]
+    [InlineData("Namespace.ClassNameWithUpperAndLower", "namespace_class_name_with_upper_and_lower")]
+    [InlineData("ALLUPPERCASE", "alluppercase")]
+    [InlineData("DIClass", "diclass")]
+    [InlineData("DiClass", "di_class")]
+    [InlineData("Di_Class", "di_class")]
+    [InlineData("di_class", "di_class")]
+    [InlineData("di__class", "di_class")]
+    public void TestToSafeHomeAssistantEntityIdFromApplicationIdShouldGiveCorrectNameDevelopment(string fromId, string toId)
+    {
+        var expected = $"input_boolean.dev_netdaemon_{toId}";
+        EntityMapperHelper.ToEntityIdFromApplicationId(fromId, true).Should().Be(expected);
     }
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/EntityMapperHelper.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/EntityMapperHelper.cs
@@ -10,9 +10,14 @@ public static class EntityMapperHelper
     ///     Converts any unicode string to a safe Home Assistant name for the helper
     /// </summary>
     /// <param name="applicationId">The unicode string to convert</param>
+    public static string ToEntityIdFromApplicationId(string applicationId, bool isDevelopment = false) =>
+        !isDevelopment ?
+            $"input_boolean.netdaemon_{ToSafeVersion(applicationId)}" :
+            $"input_boolean.dev_netdaemon_{ToSafeVersion(applicationId)}" ;
+
     [SuppressMessage("Microsoft.Globalization", "CA1308")]
     [SuppressMessage("", "CA1062")]
-    public static string ToSafeHomeAssistantEntityIdFromApplicationId(string applicationId)
+    private static string ToSafeVersion(string applicationId)
     {
         var normalizedString = applicationId.Normalize(NormalizationForm.FormD);
         StringBuilder stringBuilder = new(applicationId.Length);
@@ -47,6 +52,6 @@ public static class EntityMapperHelper
             lastChar = c;
         }
 
-        return $"input_boolean.netdaemon_{stringBuilder.ToString().ToLowerInvariant()}";
+        return stringBuilder.ToString().ToLowerInvariant();
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds specific naming rules for when is in development for input booleans app states

When in development:
- The feature that removes unused apps is disabled
- A prefix `dev_` is added not to interfere with original
- The dev version will be removed when production restarts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs