### PR TITLE
More optionality around entity creation, simplified public method signatures

### DIFF
--- a/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -15,7 +15,6 @@ using NetDaemon.HassModel;
 namespace DebugHost.apps.Extensions;
 
 [NetDaemonApp]
-[Focus]
 public class MqttEntityManagerApp : IAsyncInitializable
 {
     private readonly IHaContext _ha;

--- a/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -50,8 +50,7 @@ public class MqttEntityManagerApp : IAsyncInitializable
                 .ConfigureAwait(false);
 
             // Change state of the new sensor, set an attribute to right now
-            await _entityManager.UpdateAsync("sensor.my_id", "shiny",
-                    JsonSerializer.Serialize(new { updated = DateTime.UtcNow }))
+            await _entityManager.UpdateAsync("sensor.my_id", "shiny", new { updated = DateTime.UtcNow })
                 .ConfigureAwait(false);
 
             // Walk through a more complete set of examples, checking HA to verify that each operation completed

--- a/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NetDaemon.AppModel;
 using NetDaemon.Extensions.MqttEntityManager;
+using NetDaemon.Extensions.MqttEntityManager.Models;
 using NetDaemon.HassModel;
 
 #endregion
@@ -18,15 +19,15 @@ namespace DebugHost.apps.Extensions;
 [Focus]
 public class MqttEntityManagerApp : IAsyncInitializable
 {
-    private readonly IHaContext                    _ha;
+    private readonly IHaContext _ha;
     private readonly ILogger<MqttEntityManagerApp> _logger;
-    private readonly IMqttEntityManager            _manager;
+    private readonly IMqttEntityManager _entityManager;
 
-    public MqttEntityManagerApp(IHaContext ha, ILogger<MqttEntityManagerApp> logger, IMqttEntityManager manager)
+    public MqttEntityManagerApp(IHaContext ha, ILogger<MqttEntityManagerApp> logger, IMqttEntityManager entityManager)
     {
-        _ha      = ha;
-        _logger  = logger;
-        _manager = manager;
+        _ha = ha;
+        _logger = logger;
+        _entityManager = entityManager;
     }
 
     [SuppressMessage("Naming", "CA1727:Use PascalCase for named placeholders", Justification = "<Pending>")]
@@ -35,25 +36,52 @@ public class MqttEntityManagerApp : IAsyncInitializable
     {
         try
         {
+            // Basic entity creation
+            await _entityManager.CreateAsync("sensor.basic_sensor").ConfigureAwait(false);
+
+            // Overriding the default unique ID and name
+            await _entityManager.CreateAsync("sensor.my_id",
+                    new EntityCreationOptions(UniqueId: "my_id", Name: "A special kind of sensor"))
+                .ConfigureAwait(false);
+
+            // Switches require a device class
+            await _entityManager.CreateAsync("switch.helto_switch",
+                    new EntityCreationOptions(Name: "Helto switch", DeviceClass: "switch"))
+                .ConfigureAwait(false);
+
+            // Change state of the new sensor, set an attribute to right now
+            await _entityManager.UpdateAsync("sensor.my_id", "shiny",
+                    JsonSerializer.Serialize(new { updated = DateTime.UtcNow }))
+                .ConfigureAwait(false);
+
+            // Walk through a more complete set of examples, checking HA to verify that each operation completed
             _logger.LogInformation("Creating Entity {domain}.{entityId}", "binary_sensor", "manager_test");
-            await _manager.CreateAsync("binary_sensor", "manager_test", "motion", "Manager Test").ConfigureAwait(false);
+            var createOptions = new EntityCreationOptions(DeviceClass: "motion", Name: "Manager Test");
+            await _entityManager.CreateAsync("binary_sensor.manager_test", createOptions).ConfigureAwait(false);
             // Using Delay to give Mqtt and HA enough time to process events.
             // Only needed for the example as we immediately read the entity and it may not yet exist
             await Task.Delay(250, cancellationToken).ConfigureAwait(false);
 
             var entity = _ha.Entity("binary_sensor.manager_test");
-            _logger.LogInformation("Entity {domain}.{entityId} State: {state}", "binary_sensor", "manager_test", entity.State);
+            _logger.LogInformation("Entity {domain}.{entityId} State: {state}", "binary_sensor", "manager_test",
+                entity.State);
 
-            await _manager.UpdateAsync("binary_sensor", "manager_test", "ON", JsonSerializer.Serialize(new { attribute1 = "attr1" }))
+            await _entityManager.UpdateAsync("binary_sensor.manager_test", "ON",
+                    JsonSerializer.Serialize(new { attribute1 = "attr1" }))
                 .ConfigureAwait(false);
             await Task.Delay(250, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("Entity {domain}.{entityId} State: {state} Attributes: {attributes}",
                 "binary_sensor", "manager_test", entity.State, entity.Attributes);
 
-            await _manager.RemoveAsync("binary_sensor", "manager_test").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("binary_sensor.manager_test").ConfigureAwait(false);
             await Task.Delay(250, cancellationToken).ConfigureAwait(false);
             var removed = _ha.Entity("binary_sensor.manager_test").State == null;
             _logger.LogInformation("Removed Entity: {removed}", removed);
+
+            // Remove other entities
+            await _entityManager.RemoveAsync("sensor.basic_sensor").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("sensor.helto_switch").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("sensor.my_id").ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/dev/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -31,11 +30,18 @@ public class MqttEntityManagerApp : IAsyncInitializable
     }
 
     [SuppressMessage("Naming", "CA1727:Use PascalCase for named placeholders", Justification = "<Pending>")]
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We need to log unexpected errors")]
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types",
+        Justification = "We need to log unexpected errors")]
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
         try
         {
+            await _entityManager.RemoveAsync("binary_sensor.mqtt_test").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("binary_sensor.nd_test").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("binary_sensor.leith_tides").ConfigureAwait(false);
+            await _entityManager.RemoveAsync("input_text.sample_text_helper").ConfigureAwait(false);
+
+
             // Basic entity creation
             await _entityManager.CreateAsync("sensor.basic_sensor").ConfigureAwait(false);
 
@@ -65,8 +71,7 @@ public class MqttEntityManagerApp : IAsyncInitializable
             _logger.LogInformation("Entity {domain}.{entityId} State: {state}", "binary_sensor", "manager_test",
                 entity.State);
 
-            await _entityManager.UpdateAsync("binary_sensor.manager_test", "ON",
-                    JsonSerializer.Serialize(new { attribute1 = "attr1" }))
+            await _entityManager.UpdateAsync("binary_sensor.manager_test", "ON", new { attribute1 = "attr1" })
                 .ConfigureAwait(false);
             await Task.Delay(250, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("Entity {domain}.{entityId} State: {state} Attributes: {attributes}",

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Helpers/EntityIdParser.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Helpers/EntityIdParser.cs
@@ -1,0 +1,27 @@
+﻿namespace NetDaemon.Extensions.MqttEntityManager.Helpers;
+
+/// <summary>
+/// Parsing utilities for entity IDs
+/// </summary>
+internal static class EntityIdParser
+{
+    /// <summary>
+    /// Extract the domain and identifier from an entity ID string
+    /// </summary>
+    /// <param name="entityId">Entity ID in the format "domain.identifier"</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException">If entityId is not supplied or is an invalid
+    /// format</exception>
+    public static (string domain, string identifier) Extract(string entityId)
+    {
+        if (string.IsNullOrWhiteSpace(entityId))
+            throw new ArgumentException(nameof(entityId));
+
+        var components = entityId.Split('.', 2);
+        if (components.Length != 2)
+            throw new ArgumentException(
+                $"The {nameof(entityId)} should be of the format 'domain.identifier'. The value was {entityId}");
+        
+        return (components[0], components[1]);
+    }
+}

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
@@ -17,14 +17,8 @@ public interface IMqttEntityManager
     /// </summary>
     Task RemoveAsync(string entityId);
 
-
     /// <summary>
-    ///     Update state and, optionally, attributes of an HA entity via MQTT
+    ///     Update state and/or set attributes of an HA entity via MQTT
     /// </summary>
-    Task UpdateAsync(string entityId, string state, string? attributes = null);
-    
-    /// <summary>
-    ///     Update state and, optionally, attributes of an HA entity via MQTT
-    /// </summary>
-    Task UpdateAsync(string entityId, string state, object? attributes = null);
+    Task UpdateAsync(string entityId, string? state, object? attributes = null);
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
@@ -1,4 +1,6 @@
-﻿namespace NetDaemon.Extensions.MqttEntityManager;
+﻿using NetDaemon.Extensions.MqttEntityManager.Models;
+
+namespace NetDaemon.Extensions.MqttEntityManager;
 
 /// <summary>
 ///     Interface for managing entities via MQTT
@@ -8,17 +10,16 @@ public interface IMqttEntityManager
     /// <summary>
     ///     Create an entity in Home Assistant via MQTT
     /// </summary>
-    Task CreateAsync(string domain, string entityId, string deviceClass, string name, bool persist = true);
-
+    Task CreateAsync(string entityId, EntityCreationOptions? options = null);
 
     /// <summary>
     ///     Remove an entity from Home Assistant
     /// </summary>
-    Task RemoveAsync(string domain, string entityId);
+    Task RemoveAsync(string entityId);
 
 
     /// <summary>
     ///     Update state and, optionally, attributes of an HA entity via MQTT
     /// </summary>
-    Task UpdateAsync(string domain, string entityId, string state, string? attributes = null);
+    Task UpdateAsync(string entityId, string state, string? attributes = null);
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttEntityManager.cs
@@ -22,4 +22,9 @@ public interface IMqttEntityManager
     ///     Update state and, optionally, attributes of an HA entity via MQTT
     /// </summary>
     Task UpdateAsync(string entityId, string state, string? attributes = null);
+    
+    /// <summary>
+    ///     Update state and, optionally, attributes of an HA entity via MQTT
+    /// </summary>
+    Task UpdateAsync(string entityId, string state, object? attributes = null);
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationOptions.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace NetDaemon.Extensions.MqttEntityManager.Models;
+
+/// <summary>
+/// Paremeters to create an entity
+/// </summary>
+/// <param name="DeviceClass">Optional device class - see HA integration documentation</param>
+/// <param name="UniqueId">Optional unique ID to use - if not specified then one will be generated</param>
+/// <param name="Name">Optional name of the entity</param>
+/// <param name="Persist">Optionally persist the entity over HA restarts, default is true</param>
+public record EntityCreationOptions(
+    string? DeviceClass = null,
+    string? UniqueId = null,
+    string? Name = null,
+    bool Persist = true
+);

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationPayload.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationPayload.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+
+namespace NetDaemon.Extensions.MqttEntityManager.Models;
+
+internal class EntityCreationPayload
+{
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("device_class")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DeviceClass { get; set; }
+
+    [JsonPropertyName("unique_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? UniqueId { get; set; }
+
+    [JsonPropertyName("command_topic")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CommandTopic { get; set; }
+    
+    [JsonPropertyName("state_topic")]
+    public string? StateTopic { get; set; }
+
+    [JsonPropertyName("json_attributes_topic")]
+    public string? JsonAttributesTopic { get; set; }
+}

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
@@ -73,10 +73,15 @@ internal class MqttEntityManager : IMqttEntityManager
     public async Task UpdateAsync(string entityId, string state, string? attributes = null)
     {
         var (domain, identifier) = EntityIdParser.Extract(entityId);
-        
+
         await _messageSender.SendMessageAsync(StatePath(domain, identifier), state).ConfigureAwait(false);
         if (attributes != null)
             await _messageSender.SendMessageAsync(AttrsPath(domain, identifier), attributes).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(string entityId, string state, object? attributes = null)
+    {
+        await UpdateAsync(entityId, state, attributes != null ? JsonSerializer.Serialize(attributes) : null);
     }
 
     private string AttrsPath(string domain, string identifier) => $"{RootPath(domain, identifier)}/attributes";

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
@@ -2,6 +2,8 @@
 
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using NetDaemon.Extensions.MqttEntityManager.Helpers;
+using NetDaemon.Extensions.MqttEntityManager.Models;
 
 #endregion
 
@@ -13,7 +15,7 @@ namespace NetDaemon.Extensions.MqttEntityManager;
 internal class MqttEntityManager : IMqttEntityManager
 {
     private readonly MqttConfiguration _config;
-    private readonly IMessageSender    _messageSender;
+    private readonly IMessageSender _messageSender;
 
     /// <summary>
     ///     Manage entities via MQTT
@@ -23,58 +25,67 @@ internal class MqttEntityManager : IMqttEntityManager
     public MqttEntityManager(IMessageSender messageSender, IOptions<MqttConfiguration> config)
     {
         _messageSender = messageSender;
-        _config        = config.Value;
+        _config = config.Value;
     }
 
     /// <summary>
-    ///     Create an entity in Home Assistant via MQTT
+    /// Create an entity in Home Assistant via MQTT
     /// </summary>
-    /// <param name="domain"></param>
-    /// <param name="deviceClass"></param>
-    /// <param name="entityId"></param>
-    /// <param name="name"></param>
-    /// <param name="persist">This will persist the entity if Home Assistant restarts</param>
-    public async Task CreateAsync(string domain, string entityId, string deviceClass, string name, bool persist = true)
+    /// <param name="entityId">Distinct identifier, in the format "domain.id", such as "sensor.kitchen_temp"</param>
+    /// <param name="options">Optional set of additional parameters</param>
+    public async Task CreateAsync(string entityId, EntityCreationOptions? options)
     {
-        var payload = JsonSerializer.Serialize(new
-        {
-            name,
-            device_class          = deviceClass,
-            state_topic           = StatePath(domain, entityId),
-            json_attributes_topic = AttrsPath(domain, entityId)
-        });
-        await _messageSender.SendMessageAsync(ConfigPath(domain, entityId), payload, persist).ConfigureAwait(false);
+        var (domain, identifier) = EntityIdParser.Extract(entityId);
+        var configPath = ConfigPath(domain, identifier);
+
+        var payload = JsonSerializer.Serialize(new EntityCreationPayload
+            {
+                Name = options?.Name ?? identifier,
+                DeviceClass = options?.DeviceClass,
+                UniqueId = options?.UniqueId ?? configPath.Replace('/', '_'),
+                CommandTopic = CommandPath(domain, identifier),
+                StateTopic = StatePath(domain, identifier),
+                JsonAttributesTopic = AttrsPath(domain, identifier)
+            }
+        );
+
+        await _messageSender
+            .SendMessageAsync(configPath, payload, options?.Persist ?? true)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
     ///     Remove an entity from Home Assistant
     /// </summary>
-    /// <param name="domain"></param>
     /// <param name="entityId"></param>
-    public async Task RemoveAsync(string domain, string entityId)
+    public async Task RemoveAsync(string entityId)
     {
-        await _messageSender.SendMessageAsync(ConfigPath(domain, entityId), string.Empty).ConfigureAwait(false);
+        var (domain, identifier) = EntityIdParser.Extract(entityId);
+        await _messageSender.SendMessageAsync(ConfigPath(domain, identifier), string.Empty).ConfigureAwait(false);
     }
 
     /// <summary>
     ///     Update state and, optionally, attributes of an HA entity via MQTT
     /// </summary>
-    /// <param name="domain"></param>
     /// <param name="entityId"></param>
     /// <param name="state"></param>
     /// <param name="attributes">Json string of attributes</param>
-    public async Task UpdateAsync(string domain, string entityId, string state, string? attributes = null)
+    public async Task UpdateAsync(string entityId, string state, string? attributes = null)
     {
-        await _messageSender.SendMessageAsync(StatePath(domain, entityId), state).ConfigureAwait(false);
+        var (domain, identifier) = EntityIdParser.Extract(entityId);
+        
+        await _messageSender.SendMessageAsync(StatePath(domain, identifier), state).ConfigureAwait(false);
         if (attributes != null)
-            await _messageSender.SendMessageAsync(AttrsPath(domain, entityId), attributes).ConfigureAwait(false);
+            await _messageSender.SendMessageAsync(AttrsPath(domain, identifier), attributes).ConfigureAwait(false);
     }
 
-    private string AttrsPath(string domain, string entityId) => $"{RootPath(domain, entityId)}/attributes";
+    private string AttrsPath(string domain, string identifier) => $"{RootPath(domain, identifier)}/attributes";
 
-    private string ConfigPath(string domain, string entityId) => $"{RootPath(domain, entityId)}/config";
+    private string ConfigPath(string domain, string identifier) => $"{RootPath(domain, identifier)}/config";
 
-    private string RootPath(string domain, string entityId) => $"{_config.DiscoveryPrefix}/{domain}/{entityId}";
+    private string RootPath(string domain, string identifier) => $"{_config.DiscoveryPrefix}/{domain}/{identifier}";
 
-    private string StatePath(string domain, string entityId) => $"{RootPath(domain, entityId)}/state";
+    private string StatePath(string domain, string identifier) => $"{RootPath(domain, identifier)}/state";
+
+    private string CommandPath(string domain, string identifier) => $"{RootPath(domain, identifier)}/set";
 }


### PR DESCRIPTION
Provide more optionality around the create-entity requests.
Provide better defaults (unique_id, name) to ensure that a basic request to create an entity succeeds.
Change signatures of Create, Update and Remove to use a single `entityId` construct (like "sensor.kitchen_temp") rather than pass domain and identifier.
Expand test / sample application to show how to create a switch as well as different examples of optional arguments.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
There are two breaking changes - the requests to `CreateAsync`, `UpdateAsync` and `RemoveAsync` now require a single `entityId` argument (e.g. "sensor.kitchen_heat") rather than specifying a domain and identifier.
`UpdateAsync` no longer accepts a json string for attributes - if you have code that currently supplies this then the update will fail silently - supply a concrete or anonymous object to the method instead.

<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Provide better default options to increase the chance of the creation succeeding.
Optional record parameter to `CreateAsync()` public method to allow caller to override each of these arguments.

Added more examples

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: docs need to be updated - I'll do that

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs