### PR TITLE
Bugfix: Ensure entity_id is set as expected, when a name is provided

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/EntityCreationPayloadHelperTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/EntityCreationPayloadHelperTests.cs
@@ -14,26 +14,26 @@ public class EntityCreationPayloadHelperTests
             yield return new object[]
             {
                 new EntityCreationPayload(), new { },
-                J(new { state_topic = (object)null!, json_attributes_topic = (object)null! }),
+                J(new { state_topic = (object)null!, json_attributes_topic = (object)null!, object_id = (object)null! }),
                 "should output basic concrete options"
             };
             
             yield return new object[]
             {
                 new EntityCreationPayload {}, new { extra = "data" },
-                J(new { state_topic = (object)null!, json_attributes_topic = (object)null!, extra = "data" }), "should merge a new property"
+                J(new { state_topic = (object)null!, json_attributes_topic = (object)null!, object_id = (object)null!, extra = "data" }), "should merge a new property"
             };
             
             yield return new object[]
             {
                 new EntityCreationPayload { StateTopic = "/state"}, new {},
-                J(new { state_topic = "/state", json_attributes_topic = (object)null! }), "should pick up values"
+                J(new { state_topic = "/state", json_attributes_topic = (object)null!, object_id = (object)null!  }), "should pick up values"
             };
             
             yield return new object[]
             {
                 new EntityCreationPayload { StateTopic = "/state"}, new { state_topic = "/new-state"},
-                J(new { state_topic = "/new-state", json_attributes_topic = (object)null! }), "should override concrete values"
+                J(new { state_topic = "/new-state", json_attributes_topic = (object)null!, object_id = (object)null!  }), "should override concrete values"
             };
         }
 

--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/MqttEntityManagerTester.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/MqttEntityManagerTester.cs
@@ -25,9 +25,10 @@ public class MqttEntityManagerTester
         await entityManager.CreateAsync("domain.sensor");
         var payload = PayloadToDictionary(mqttSetup.LastPublishedMessage.Payload);
 
-        payload?.Count.Should().Be(5);
+        payload?.Count.Should().Be(6);
         payload?["name"].ToString().Should().Be("sensor");
         payload?["unique_id"].ToString().Should().Be("homeassistant_domain_sensor_config");
+        payload?["object_id"].ToString().Should().Be("sensor");
         payload?["command_topic"].ToString().Should().Be("homeassistant/domain/sensor/set");
         payload?["state_topic"].ToString().Should().Be("homeassistant/domain/sensor/state");
         payload?["json_attributes_topic"].ToString().Should().Be("homeassistant/domain/sensor/attributes");
@@ -42,9 +43,10 @@ public class MqttEntityManagerTester
         await entityManager.CreateAsync("domain.sensor", new EntityCreationOptions());
         var payload = PayloadToDictionary(mqttSetup.LastPublishedMessage.Payload);
 
-        payload?.Count.Should().Be(5);
+        payload?.Count.Should().Be(6);
         payload?["name"].ToString().Should().Be("sensor");
         payload?["unique_id"].ToString().Should().Be("homeassistant_domain_sensor_config");
+        payload?["object_id"].ToString().Should().Be("sensor");
         payload?["command_topic"].ToString().Should().Be("homeassistant/domain/sensor/set");
         payload?["state_topic"].ToString().Should().Be("homeassistant/domain/sensor/state");
         payload?["json_attributes_topic"].ToString().Should().Be("homeassistant/domain/sensor/attributes");
@@ -60,6 +62,18 @@ public class MqttEntityManagerTester
         var payload = PayloadToDictionary(mqttSetup.LastPublishedMessage.Payload);
 
         payload?["unique_id"].ToString().Should().Be("my_id");
+    }
+
+    [Fact]
+    public async Task CreateSetsObjectId()
+    {
+        var mqttSetup = new MockMqttMessageSenderSetup();
+        var entityManager = new MqttEntityManager(mqttSetup.MessageSender, GetOptions());
+
+        await entityManager.CreateAsync("domain.the_id");
+        var payload = PayloadToDictionary(mqttSetup.LastPublishedMessage.Payload);
+
+        payload?["object_id"].ToString().Should().Be("the_id");
     }
 
     [Fact]

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationPayload.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Models/EntityCreationPayload.cs
@@ -18,6 +18,9 @@ internal class EntityCreationPayload
     [JsonPropertyName("unique_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? UniqueId { get; set; }
+    
+    [JsonPropertyName("object_id")]
+    public string? ObjectId { get; set; }
 
     [JsonPropertyName("command_topic")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttEntityManager.cs
@@ -123,6 +123,7 @@ internal class MqttEntityManager : IMqttEntityManager
             Name = options?.Name ?? identifier,
             DeviceClass = options?.DeviceClass,
             UniqueId = options?.UniqueId ?? configPath.Replace('/', '_'),
+            ObjectId = identifier,
             CommandTopic = CommandPath(domain, identifier),
             StateTopic = StatePath(domain, identifier),
             PayloadAvailable = options?.PayloadAvailable,


### PR DESCRIPTION
Addresses a bug where specifying the name for an entity via `MqttEntityManager.CreateAsync()` would result in its `entity_id` being set to a variation of that name.


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
This is likely to expose some breaking changes to people who think they have created entities with a specific ID but it turns out to have a different ID.
That said, it's a "soft" break as the command topics are still built from the original entity_id so setting state, attributes and removing it via MQTT will have worked, however subscribing to it in HA / NetDaemon would probably have failed as the subscription would be against a non-existent entity ID.

## Proposed change
Always set the `object_id` to the identifier part of "domain.identifier". Note that, as with any other properties, this can be overridden via the `additionalConfig` argument.

Unit tests expanded to cover `object_id`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

I don't think the docs need updated

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs