### PR TITLE
Support labeled selects in CodeGenerator

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs
@@ -97,9 +97,32 @@ internal static class JsonExtensions
                 element.WriteTo(writer);
             }
 
-            return JsonSerializer.Deserialize(bufferWriter.WrittenSpan,
+            if (element.ValueKind == JsonValueKind.Object && string.Equals("select", selectorName, StringComparison.OrdinalIgnoreCase))
+            {
+                var labeledSelectorType = typeof(LabeledSelectSelector);
+
+                try
+                {
+                    return JsonSerializer.Deserialize(bufferWriter.WrittenSpan,
+                    labeledSelectorType,
+                    SnakeCaseNamingPolicySerializerOptions);
+                }
+                catch (Exception ex)
+                {
+                    // Not a labeled select, let the normal deserializer handle it as a SelectSelector
+                }
+            }
+
+            try
+            {
+                return JsonSerializer.Deserialize(bufferWriter.WrittenSpan,
                 selectorType,
                 SnakeCaseNamingPolicySerializerOptions);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException();
+            }
         }
 
         HassServiceField getField(string fieldName, JsonElement element)

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/Selectors.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/Selectors.cs
@@ -74,6 +74,24 @@ internal record SelectSelector
     public IReadOnlyCollection<string>? Options { get; init; }
 }
 
+internal record LabeledSelectSelector
+{
+    [JsonIgnore]
+    public IReadOnlyCollection<string> Options { get { return _Options.Select(o => o.Value).ToList(); } init { } }
+
+    [Required]
+    [JsonPropertyName("options")]
+    public IReadOnlyCollection<OptionSelector>? _Options { get; init; }
+}
+
+internal record OptionSelector
+{
+    [JsonPropertyName("label")]
+    public string? Label { get; init; }
+    [JsonPropertyName("value")]
+    public string? Value { get; init; }
+}
+
 internal record TargetSelector
 {
     public AreaSelector? Area { get; init; }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Some option enumerables returned from HA will present options as label/value pairs starting with 2022.4 instead of just a string[] value. I added a new LabeledSelectSelector that will extract the string values. Note that not all selects in 2022.4 return as label/value pairs, some are still string[] and JSON deserialization has been altered to reflect this.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs