### PR TITLE
Generate IReadOnlyList properties for json arrays

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/AttributeTypeGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/AttributeTypeGenerator.cs
@@ -14,8 +14,8 @@ internal class AttributeTypeGenerator
         _baseTypes = codeGenerationSettings.UseAttributeBaseClasses ? typeof(LightAttributesBase).Assembly.GetTypes() : Type.EmptyTypes;
         _entitySet = entitySet;
     }
-    
-        /// <summary>
+
+    /// <summary>
     /// Generates a record with all the attributes found in a set of entities providing unique names for each.
     /// </summary>
     public RecordDeclarationSyntax GenerateAttributeRecord()
@@ -26,14 +26,14 @@ internal class AttributeTypeGenerator
         var baseType = FindBaseClass(_entitySet.AttributesClassName);
 
         var basePropertyNames = baseType?.GetProperties().Select(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? p.Name).ToHashSet() ?? new HashSet<string>();
-        
+
         // Group the attributes by JsonPropertyName and find the best ClrType that fits all
         var attributesByJsonName = jsonProperties
             .Where(p => !basePropertyNames.Contains(p.Name)) // skip properties already defined in the base class
             .GroupBy(p => p.Name)
             .Select(group => (CSharpName: group.Key.ToNormalizedPascalCase(),
-                JsonName: group.Key, 
-                ClrType: GetBestClrType(group)));
+                JsonName: group.Key,
+                ClrType: GetBestClrType(group.Select(g => g.Value))));
 
         // We might have different json names that after CamelCasing result in the same CSharpName 
         var uniqueProperties = attributesByJsonName
@@ -62,19 +62,33 @@ internal class AttributeTypeGenerator
         return list.OrderBy(i => i.JsonName).Select((p, i) => ($"{p.CSharpName}_{i}", jsonName: p.JsonName, type: p.ClrType));
     }
 
-    private static Type GetBestClrType(IEnumerable<JsonProperty> valueKinds)
+    private static Type GetBestClrType(IEnumerable<JsonElement> valueKinds)
     {
         var distinctCrlTypes = valueKinds
-            .Select(p => p.Value.ValueKind)
-            .Distinct()
-            .Where(k => k!= JsonValueKind.Null) // null fits in any type so we can ignore it for now
-            .Select(MapJsonType)
+            .Where(e => e.ValueKind != JsonValueKind.Null) // null fits in any type so we can ignore it for now
+            .GroupBy(e => MapJsonType(e.ValueKind))
             .ToHashSet();
 
-        // If all have the same clr type use that, if not it will be 'object'
-        return distinctCrlTypes.Count == 1
-            ? distinctCrlTypes.First()
-            : typeof(object);
+        if (distinctCrlTypes.Count is 0 or > 1)
+        {
+            // Either all inputs where JsonValueKind.Null, or there are multiple possible
+            // input types. In either case, the return must be object
+            return typeof(object);
+        }
+
+        // For arrays, we want to enumerate the subelements of the array. If there's a single
+        // element type, then we'll construct an IROList<subtype>, otherwise we'll construct
+        // IROList<object>
+        var clrTypeGroup = distinctCrlTypes.Single();
+        if (clrTypeGroup.Key == typeof(IReadOnlyList<>))
+        {
+            var listSubType = GetBestClrType(clrTypeGroup.SelectMany(el => el.EnumerateArray()));
+            return clrTypeGroup.Key.MakeGenericType(listSubType);
+        }
+        else
+        {
+            return clrTypeGroup.Key;
+        }
     }
 
     private static Type MapJsonType(JsonValueKind kind) =>
@@ -83,7 +97,7 @@ internal class AttributeTypeGenerator
             JsonValueKind.False => typeof(bool),
             JsonValueKind.Undefined => typeof(object),
             JsonValueKind.Object => typeof(object),
-            JsonValueKind.Array => typeof(object),
+            JsonValueKind.Array => typeof(IReadOnlyList<>),
             JsonValueKind.String => typeof(string),
             JsonValueKind.Number => typeof(double),
             JsonValueKind.True => typeof(bool),

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
@@ -204,6 +204,7 @@ public class Root
         string? friendlyName0 = light1.Attributes?.FriendlyName_0;
         string? friendlyName1 = light1.Attributes?.FriendlyName_1;
         string? startDate = light1.Attributes?.StartDate;
+        string? arrElement1 = light1.Attributes?.Arr?[0];
     }
 }";
         AssertCodeCompiles(generatedCode, appCode);


### PR DESCRIPTION
Updates the json parser to recursively generate types based on array content, rather than directly turning arrays into `object`.
