### PR TITLE
Mqttnet 4

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/MessageSenderTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/MessageSenderTests.cs
@@ -1,6 +1,4 @@
-﻿using MQTTnet.Client.Publishing;
-using MQTTnet.Protocol;
-using NetDaemon.Extensions.MqttEntityManager.Exceptions;
+﻿using MQTTnet.Protocol;
 using NetDaemon.HassClient.Tests.ExtensionsTest.MqttEntityManagerTests.TestHelpers;
 
 namespace NetDaemon.HassClient.Tests.ExtensionsTest.MqttEntityManagerTests;
@@ -41,21 +39,6 @@ public class MessageSenderTests
         var publishedMessage = mqttSetup.LastPublishedMessage;
 
         publishedMessage.Retain.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task FailedSendThrows()
-    {
-        var mqttSetup = new MockMqttMessageSenderSetup();
-        mqttSetup.SetResponseCode(MqttClientPublishReasonCode.UnspecifiedError);
-
-        Func<Task> f = async () =>
-        {
-            await mqttSetup.MessageSender.SendMessageAsync("topic", "payload", true,
-                MqttQualityOfServiceLevel.AtMostOnce);
-        };
-
-        await f.Should().ThrowAsync<MqttPublishException>();
     }
 
     [Fact]

--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/TestHelpers/MockMqttMessageSenderSetup.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/TestHelpers/MockMqttMessageSenderSetup.cs
@@ -1,5 +1,5 @@
 ﻿using MQTTnet;
-using MQTTnet.Client.Publishing;
+using MQTTnet.Client;
 using MQTTnet.Extensions.ManagedClient;
 using NetDaemon.Extensions.MqttEntityManager;
 using NetDaemon.Extensions.MqttEntityManager.Helpers;
@@ -22,21 +22,20 @@ internal class MockMqttMessageSenderSetup
     {
         SetupMockMqtt();
         SetupMessageSender();
-        SetResponseCode(MqttClientPublishReasonCode.Success);
+        SetupMessageReceiver();
     }
 
-    public void SetResponseCode(MqttClientPublishReasonCode code)
+    // ReSharper disable once MemberCanBePrivate.Global
+    public void SetupMessageReceiver()
     {
-        var publishResult = new MqttClientPublishResult() { ReasonCode = code };
+        var publishResult = new MqttClientPublishResult() { ReasonCode = MqttClientPublishReasonCode.Success };
         
-        // Ensure that when the MQTT Client is called, it's published message is saved and that it returns
-        // the specified response code
-        MqttClient.Setup(m => m.PublishAsync(It.IsAny<MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
-            .Callback<MqttApplicationMessage, CancellationToken>((message, token) =>
+        // Ensure that when the MQTT Client is called its published message is saved
+        MqttClient.Setup(m => m.EnqueueAsync(It.IsAny<MqttApplicationMessage>()))
+            .Callback<MqttApplicationMessage>((message) =>
             {
                 LastPublishedMessage = message;
-            })
-            .ReturnsAsync(publishResult);
+            });
     }
 
     /// <summary>

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/DependencyInjectionSetup.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/DependencyInjectionSetup.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using MQTTnet;
 using NetDaemon.Extensions.MqttEntityManager.Helpers;
 
 #endregion
@@ -23,7 +22,7 @@ public static class DependencyInjectionSetup
     {
         return hostBuilder.ConfigureServices((context, services) =>
         {
-            services.AddSingleton<IMqttFactory, MqttFactory>();
+            services.AddSingleton<IMqttFactory, MqttFactoryFactory>();
             services.AddSingleton<IMqttFactoryWrapper, MqttFactoryWrapper>();
             services.AddSingleton<IMqttEntityManager, MqttEntityManager>();
             services.AddSingleton<IAssuredMqttConnection, AssuredMqttConnection>();

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Helpers/MqttFactoryWrapper.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/Helpers/MqttFactoryWrapper.cs
@@ -1,5 +1,4 @@
-﻿using MQTTnet;
-using MQTTnet.Extensions.ManagedClient;
+﻿using MQTTnet.Extensions.ManagedClient;
 
 namespace NetDaemon.Extensions.MqttEntityManager.Helpers;
 
@@ -35,6 +34,7 @@ internal class MqttFactoryWrapper : IMqttFactoryWrapper
     /// <returns></returns>
     public IManagedMqttClient CreateManagedMqttClient()
     {
-        return _client == null ? _mqttFactory.CreateManagedMqttClient() : _client;
+        return _client ?? _mqttFactory?.CreateManagedMqttClient() 
+            ?? throw new InvalidOperationException("No client or MqttFactory specified");
     }
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttFactory.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IMqttFactory.cs
@@ -1,0 +1,16 @@
+﻿using MQTTnet.Extensions.ManagedClient;
+
+namespace NetDaemon.Extensions.MqttEntityManager;
+
+/// <summary>
+/// MqttNet removed the IMqttFactory interface at v4 which breaks our DI
+/// So this is a factory for the MqttFactory to satisfy our use case
+/// </summary>
+internal interface IMqttFactory
+{
+    /// <summary>
+    /// Create a Managed Mqtt Client
+    /// </summary>
+    /// <returns></returns>
+    IManagedMqttClient CreateManagedMqttClient();
+}

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MessageSender.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MessageSender.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Extensions.Logging;
 using MQTTnet;
-using MQTTnet.Client.Publishing;
 using MQTTnet.Extensions.ManagedClient;
 using MQTTnet.Protocol;
 using NetDaemon.Extensions.MqttEntityManager.Exceptions;
@@ -57,9 +56,7 @@ internal class MessageSender : IMessageSender
 
         try
         {
-            var publishResult = await mqttClient.PublishAsync(message, CancellationToken.None).ConfigureAwait(false);
-            if (publishResult.ReasonCode != MqttClientPublishReasonCode.Success)
-                throw new MqttPublishException(publishResult.ReasonString);
+            await mqttClient.EnqueueAsync(message).ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttFactoryFactory.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/MqttFactoryFactory.cs
@@ -1,0 +1,20 @@
+﻿using MQTTnet;
+using MQTTnet.Extensions.ManagedClient;
+
+namespace NetDaemon.Extensions.MqttEntityManager;
+
+/// <summary>
+/// MqttNet removed the IMqttFactory interface at v4 which breaks our DI
+/// So this is a factory for the MqttFactory to satisfy our use case
+/// </summary>
+internal class MqttFactoryFactory : IMqttFactory
+{
+    /// <summary>
+    /// Create a Managed Mqtt Client
+    /// </summary>
+    /// <returns></returns>
+    public IManagedMqttClient CreateManagedMqttClient()
+    {
+        return new MqttFactory().CreateManagedMqttClient();
+    }
+}

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
@@ -27,7 +27,7 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="MQTTnet" Version="3.1.2" />
+      <PackageReference Include="MQTTnet" Version="4.0.1.184" />
       <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="3.1.2" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
     </ItemGroup>

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
@@ -28,7 +28,7 @@
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       <PackageReference Include="MQTTnet" Version="4.0.1.184" />
-      <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="3.1.2" />
+      <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.0.1.184" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Support MqttNet v4

### Non-breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Based on `dependabot/nuget/MQTTnet-4.0.1.184` branch

1. IMqttFactory removed so substituted an internal version that is only called in our `UseNetDaemonMqttEntityManagement` DI setup method
2. Multiple `MQTTnet.*` namespaces collapsed to fewer
3. PublishAsync() is now EnqueueAsync()
4. EnqueueAsync() does not support a CancellationToken and does not return a success / fail status
5. UseApplicationMessageReceivedHander() has been replaced with event subscriptions `OnMessageReceivedAsync`
6. Managed Mqtt Client connection/disconnection have changed from delegates to events

The public interfaces to the `IMQTTEntityManager` are unchanged so there should be no updates to client code required.

**[ugliness warning]** The upstream library retains `MqttFactory` but deleted `IMqttFactory`. To make things even more challenging they sealed `MqttFactory`...
So I have created our own `IMqttFactory` to retain current workflow, however there is now a new class called `MqttFactoryFactory`, which calls into the original `MqttFactory` to create the client. It's an ugly name but is descriptive(!) and is internal to the extension so users shouldn't see it.
Open to alternative suggestions though!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: _no doc changes necessary_

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been ~added~ _updated_ to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs