### PR TITLE
Feature/use net daemon app settings pull configure services

### DIFF
--- a/src/Runtime/NetDaemon.Runtime/Common/Extensions/HostBuilderExtensions.cs
+++ b/src/Runtime/NetDaemon.Runtime/Common/Extensions/HostBuilderExtensions.cs
@@ -10,11 +10,9 @@ public static class HostBuilderExtensions
     public static IHostBuilder UseNetDaemonAppSettings(this IHostBuilder hostBuilder)
     {
         return hostBuilder
-            .ConfigureServices((context, services) =>
-            {
-                services.Configure<AppConfigurationLocationSetting>(context.Configuration.GetSection("NetDaemon"));
-                services.Configure<HomeAssistantSettings>(context.Configuration.GetSection("HomeAssistant"));
-            })
+            .ConfigureServices((context, services)
+                => services.ConfigureNetDaemonServices(context.Configuration)
+            )
             .ConfigureAppConfiguration((ctx, config) =>
             {
                 config.SetBasePath(Directory.GetCurrentDirectory());

--- a/src/Runtime/NetDaemon.Runtime/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Runtime/NetDaemon.Runtime/Common/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+using NetDaemon.AppModel;
+
+namespace NetDaemon.Runtime;
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureNetDaemonServices(this IServiceCollection services, IConfiguration config)
+    {
+        return services.Configure<AppConfigurationLocationSetting>(config.GetSection("NetDaemon"))
+                       .Configure<HomeAssistantSettings>(config.GetSection("HomeAssistant"));
+    }
+}


### PR DESCRIPTION
## Breaking change


## Proposed change
Add an extension method on IServiceCollection that adds the 2 dependancies currently baked into UseNetDaemonAppSettings. This new method can be called from the existing HostbuilderExtensions.UseNetDaemonAppSettings to maintain backwards compatibility while allowing a single spot to add dependancies needed for the app. Therefore if someone chooses to manually set up the config providers they do not need to keep up on adding dependancies when changes are made in the future.



## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 1
- This PR is related to issue: https://github.com/net-daemon/netdaemon/issues/697
- Link to documentation pull request: https://github.com/net-daemon/docs/pull/137

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]



[docs-repository]: https://github.com/net-daemon/docs