### PR TITLE
SubscribeSafe

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Tests/ObservableExtensionsTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/ObservableExtensionsTest.cs
@@ -9,61 +9,111 @@ namespace NetDaemon.HassModel.Tests;
 
 public class ObservableExtensionsTest
 {
-
     [Fact]
     public void TestSubscribeAsyncShouldCallAsyncFunction()
     {
         var testSubject = new Subject<string>();
-        var observerMock = new Mock<IObserver<string>>();
         var str = string.Empty;
-        
-        testSubject.SubscribeAsync((a) =>
+
+        testSubject.SubscribeAsync(a =>
         {
             str = a;
             return Task.CompletedTask;
         });
-        
+
         testSubject.OnNext("hello");
         str.Should().Be("hello");
-    }    
-    
+    }
+
+    [Fact]
+    public void TestSubscribeSafeShouldCallFunction()
+    {
+        var testSubject = new Subject<string>();
+        var str = string.Empty;
+
+        testSubject.SubscribeSafe(a => { str = a; });
+
+        testSubject.OnNext("hello");
+        str.Should().Be("hello");
+    }
+
     [Fact]
     public void TestSubscribeAsyncConcurrentShouldCallAsyncFunction()
     {
         var testSubject = new Subject<string>();
         var observerMock = new Mock<IObserver<string>>();
         var str = string.Empty;
-        
-        testSubject.SubscribeAsyncConcurrent((a) =>
+
+        testSubject.SubscribeAsyncConcurrent(a =>
         {
             str = a;
             return Task.CompletedTask;
         });
-        
+
         testSubject.OnNext("hello");
         str.Should().Be("hello");
-    }    
-    
+    }
+
     [Fact]
     public void TestSubscribeAsyncExceptionShouldCallErrorCallback()
     {
         var testSubject = new Subject<string>();
-        bool errorCalled = false;
-        var subscriber = testSubject.SubscribeAsync((a) => throw new InvalidOperationException(),
+        var errorCalled = false;
+        var subscriber = testSubject.SubscribeAsync(a => throw new InvalidOperationException(),
             e => errorCalled = true);
-        
+
         testSubject.OnNext("hello");
         errorCalled.Should().BeTrue();
-    }    
-    
+    }
+
+    [Fact]
+    public void TestSubscribeAsyncExceptionShouldNotStopAfterException()
+    {
+        var testSubject = new Subject<string>();
+        var nrCalled = 0;
+        var subscriber = testSubject.SubscribeAsync(a => throw new InvalidOperationException(),
+            e => nrCalled++);
+
+        testSubject.OnNext("hello");
+        testSubject.OnNext("hello");
+
+        nrCalled.Should().Be(2);
+    }
+
+    [Fact]
+    public void TestSubscribeSafeExceptionShouldCallErrorCallback()
+    {
+        var testSubject = new Subject<string>();
+        var errorCalled = false;
+        var subscriber = testSubject.SubscribeSafe(a => throw new InvalidOperationException(),
+            e => errorCalled = true);
+
+        testSubject.OnNext("hello");
+        errorCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TestSubscribeSafeMultipleExceptionShouldNotStopAfterException()
+    {
+        var testSubject = new Subject<string>();
+        var nrCalled = 0;
+        var subscriber = testSubject.SubscribeSafe(a => throw new InvalidOperationException(),
+            e => nrCalled++);
+
+        testSubject.OnNext("hello");
+        testSubject.OnNext("hello");
+
+        nrCalled.Should().Be(2);
+    }
+
     [Fact]
     public void TestSubscribeAsyncConcurrentExceptionShouldCallErrorCallback()
     {
         var testSubject = new Subject<string>();
-        bool errorCalled = false;
-        var subscriber = testSubject.SubscribeAsyncConcurrent((a) => throw new InvalidOperationException(),
+        var errorCalled = false;
+        var subscriber = testSubject.SubscribeAsyncConcurrent(a => throw new InvalidOperationException(),
             e => errorCalled = true);
-        
+
         testSubject.OnNext("hello");
         errorCalled.Should().BeTrue();
     }

--- a/src/HassModel/NetDeamon.HassModel/ObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/ObservableExtensions.cs
@@ -105,8 +105,11 @@ public static class ObservableExtensions
             }
             else
             {
-                using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
-                logger ??= loggerFactory.CreateLogger<IHaContext>();
+                if (logger is null)
+                {
+                    using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
+                    logger = loggerFactory.CreateLogger<IHaContext>();
+                }
                 logger.LogError(ex,
                     "Error on SubscribeSafe");
             }
@@ -130,9 +133,11 @@ public static class ObservableExtensions
             }
             else
             {
-                using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
-                logger = logger ??= loggerFactory.CreateLogger<IHaContext>();
-
+                if (logger is null)
+                {
+                    using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
+                    logger = loggerFactory.CreateLogger<IHaContext>();
+                }
                 logger.LogError(ex,
                     "SubscribeConcurrent throws an unhandled Exception, please use error callback function to do proper logging");
             }

--- a/src/HassModel/NetDeamon.HassModel/ObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/ObservableExtensions.cs
@@ -9,16 +9,15 @@ public static class ObservableExtensions
     ///     Allows calling async function but does this in a serial way. Long running tasks will block
     ///     other subscriptions
     /// </summary>
-    public static IDisposable SubscribeAsync<T>(this IObservable<T> source, Func<T, Task> onNextAsync, Action<Exception>? onError = null)
+    public static IDisposable SubscribeAsync<T>(this IObservable<T> source, Func<T, Task> onNextAsync,
+        Action<Exception>? onError = null)
     {
         return source
-            .Select(e => Observable.FromAsync(() => HandleTask(onNextAsync, e, onError)))
+            .Select(e => Observable.FromAsync(() => HandleTaskSafeAsync(onNextAsync, e, onError)))
             .Concat()
             .Subscribe();
     }
 
-    // public static IDisposable Subscribe<T>([NotNull] this IObservable<T> source, [NotNull] Action<T> onNext)
-    //     in class ObservableExtensions
     /// <summary>
     ///     Allows calling async function. Order of messages is not guaranteed
     /// </summary>
@@ -26,12 +25,61 @@ public static class ObservableExtensions
         Action<Exception>? onError = null)
     {
         return source
-            .Select(async e => await Observable.FromAsync(() => HandleTask(onNextAsync, e, onError)))
+            .Select(async e => await Observable.FromAsync(() => HandleTaskSafeAsync(onNextAsync, e, onError)))
             .Merge()
             .Subscribe();
-    }    
-    
-    private static async Task HandleTask<T>(Func<T, Task> onNextAsync, T e, Action<Exception>? onError = null)
+    }
+
+    /// <summary>
+    ///     Allows calling async function with max nr of concurrent messages. Order of messages is not guaranteed
+    /// </summary>
+    public static IDisposable SubscribeAsyncConcurrent<T>(this IObservable<T> source, Func<T, Task> onNextAsync,
+        int maxConcurrent)
+    {
+        return source
+            .Select(e => Observable.FromAsync(() => HandleTaskSafeAsync(onNextAsync, e)))
+            .Merge(maxConcurrent)
+            .Subscribe();
+    }
+
+    /// <summary>
+    ///     Subscribe safely where unhandled exception does not unsubscribe and always log error
+    /// </summary>
+    public static IDisposable SubscribeSafe<T>(this IObservable<T> source, Action<T> onNext,
+        Action<Exception>? onError = null)
+    {
+        return source
+            .Select(e => HandleTaskSafe(onNext, e, onError))
+            .Subscribe();
+    }
+
+    [SuppressMessage("", "CA1031")]
+    private static T HandleTaskSafe<T>(Action<T> onNext, T e, Action<Exception>? onError = null)
+    {
+        try
+        {
+            onNext(e);
+        }
+        catch (Exception ex)
+        {
+            if (onError is not null)
+            {
+                onError(ex);
+            }
+            else
+            {
+                using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
+                var logger = loggerFactory.CreateLogger<IHaContext>();
+                logger.LogError(ex,
+                    "Error on SubscribeSafe");
+            }
+        }
+
+        return e;
+    }
+
+    [SuppressMessage("", "CA1031")]
+    private static async Task HandleTaskSafeAsync<T>(Func<T, Task> onNextAsync, T e, Action<Exception>? onError = null)
     {
         try
         {
@@ -45,24 +93,12 @@ public static class ObservableExtensions
             }
             else
             {
-                var logger = LoggerFactory.Create(x => { x.AddConsole(); }).CreateLogger<IHaContext>();
+                using var loggerFactory = LoggerFactory.Create(x => { x.AddConsole(); });
+                var logger = loggerFactory.CreateLogger<IHaContext>();
 
                 logger.LogError(ex,
                     "SubscribeConcurrent throws an unhandled Exception, please use error callback function to do proper logging");
-                throw;
             }
         }
-    }
-
-    /// <summary>
-    ///     Allows calling async function with max nr of concurrent messages. Order of messages is not guaranteed
-    /// </summary>
-    public static IDisposable SubscribeAsyncConcurrent<T>(this IObservable<T> source, Func<T, Task> onNextAsync,
-        int maxConcurrent)
-    {
-        return source
-            .Select(e => Observable.FromAsync(() => HandleTask(onNextAsync, e)))
-            .Merge(maxConcurrent)
-            .Subscribe();
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changes behaviour of SubscribeAsync and SubscribeAsyncConcurrent to safely recover from unhandled exception. This was the intended behaviour from the beginning so technically it is a bugfix.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a safe subscription. Safe means it will recover from unhandled exceptions and continue process messages. Normal Subscribe would unsubscribe all subscribers when unhandled exceptions occurs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs