### PR TITLE
Added MediaPlayerAttributesBase Class & Fixed Types in LightAttributesBase Class

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
@@ -65,7 +65,7 @@ internal static class NamingHelper
     public static string SimplifyTypeName(Type type)
     {
         // Use short name if the type is in one of the using namespaces
-        return  UsingNamespaces.Any(u => type.Namespace == u) ? type.Name : type.FullName!;
+        return UsingNamespaces.Any(u => type.Namespace == u) ? type.Name : type.FullName!;
     }
 
     public static readonly string[] UsingNamespaces =

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
@@ -119,9 +119,9 @@ async Task<(IReadOnlyCollection<HassState> states, IReadOnlyCollection<HassServi
     await using var connection = await client.ConnectAsync(homeAssistantSettings.Host, homeAssistantSettings.Port, homeAssistantSettings.Ssl, homeAssistantSettings.Token, CancellationToken.None).ConfigureAwait(false);
 
     var services = await connection.GetServicesAsync(CancellationToken.None).ConfigureAwait(false);
-    var serviceDmains = services!.Value.ToServicesResult();
+    var serviceDomains = services!.Value.ToServicesResult();
 
     var states = await connection.GetStatesAsync(CancellationToken.None).ConfigureAwait(false);
 
-    return (states!, serviceDmains);
+    return (states!, serviceDomains);
 }

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
@@ -107,7 +107,7 @@ IConfigurationRoot GetConfigurationRoot()
     return builder.Build();
 }
 
-async Task<(IReadOnlyCollection<HassState> states, IReadOnlyCollection<HassServiceDomain> serviceDmains)> GetHaData(HomeAssistantSettings homeAssistantSettings)
+async Task<(IReadOnlyCollection<HassState> states, IReadOnlyCollection<HassServiceDomain> serviceDomains)> GetHaData(HomeAssistantSettings homeAssistantSettings)
 {
     Console.WriteLine($"Connecting to Home Assistant at {homeAssistantSettings.Host}:{homeAssistantSettings.Port}");
 

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -3,9 +3,6 @@
 
 public record LightAttributesBase
 {
-    [JsonPropertyName("entity_id")]
-    public IReadOnlyList<string>? EntityId { get; init; }
-
     /// <summary>
     /// Integer between 0 and 255 for how bright the light should be, where 0 means the light is off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
     /// </summary>
@@ -14,21 +11,42 @@ public record LightAttributesBase
     
     [JsonPropertyName("color_mode")]
     public string? ColorMode { get; init; }
+    
+    /// <summary>
+    /// Integer in mireds representing the color temperature of the light.
+    /// </summary>
+    [JsonPropertyName("color_temp")]
+    public int? ColorTemp { get; init; }
 
     /// <summary>
     /// The current effect.
     /// </summary>
     [JsonPropertyName("effect")]
     public string? Effect { get; init; }
-    
+
     /// <summary>
     /// The list of supported effects.
     /// </summary>
     [JsonPropertyName("effect_list")]
     public IReadOnlyList<string>? EffectList { get; init; }
+    
+    /// <summary>
+    /// Entity ids of the entities in the light group. Null if not a group.
+    /// </summary>
+    [JsonPropertyName("entity_id")]
+    public IReadOnlyList<string>? EntityId { get; init; }
 
+    /// <summary>
+    /// Name of the light as displayed in the UI.
+    /// </summary>
     [JsonPropertyName("friendly_name")]
     public string? FriendlyName { get; init; }
+    
+    /// <summary>
+    /// List containing two floats representing the hue and saturation of the color of the light. Hue is scaled 0-360, and saturation is scaled 0-100.
+    /// </summary>
+    [JsonPropertyName("hs_color")]
+    public IReadOnlyList<double>? HsColor { get; init; }
 
     [JsonPropertyName("icon")]
     public string? Icon { get; init; }
@@ -44,24 +62,6 @@ public record LightAttributesBase
     /// </summary>
     [JsonPropertyName("min_mireds")]
     public int? MinMireds { get; init; }
-    
-    [JsonPropertyName("supported_color_modes")]
-    public IReadOnlyList<string>? SupportedColorModes { get; init; }
-    
-    [JsonPropertyName("supported_features")]
-    public int? SupportedFeatures { get; init; }
-    
-    /// <summary>
-    /// Integer in mireds representing the color temperature of the light.
-    /// </summary>
-    [JsonPropertyName("color_temp")]
-    public int? ColorTemp { get; init; }
-
-    /// <summary>
-    /// List containing two floats representing the hue and saturation of the color of the light. Hue is scaled 0-360, and saturation is scaled 0-100.
-    /// </summary>
-    [JsonPropertyName("hs_color")]
-    public IReadOnlyList<double>? HsColor { get; init; }
 
     /// <summary>
     /// List containing three integers between 0 and 255 representing the RGB color (red, green, blue) of the light. Three comma-separated integers that represent the color in RGB.
@@ -80,6 +80,12 @@ public record LightAttributesBase
     /// </summary>
     [JsonPropertyName("rgbww_color")]
     public IReadOnlyList<int>? RgbwwColor { get; init; }
+    
+    [JsonPropertyName("supported_color_modes")]
+    public IReadOnlyList<string>? SupportedColorModes { get; init; }
+    
+    [JsonPropertyName("supported_features")]
+    public int? SupportedFeatures { get; init; }
 
     /// <summary>
     /// List containing two floats representing the xy color of the light. Two comma-separated floats that represent the color in XY.

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -3,42 +3,90 @@
 
 public record LightAttributesBase
 {
-    [JsonPropertyName("entity_id")] public object? EntityId { get; init; }
+    [JsonPropertyName("entity_id")]
+    public object? EntityId { get; init; }
 
     /// <summary>
     /// Integer between 0 and 255 for how bright the light should be, where 0 means the light is off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
     /// </summary>
-    [JsonPropertyName("brightness")] public int? Brightness { get; init; }
-
-    [JsonPropertyName("color_mode")] public string? ColorMode { get; init; }
-
-    [JsonPropertyName("effect_list")] public IReadOnlyList<string>? EffectList { get; init; }
-
-    [JsonPropertyName("friendly_name")] public string? FriendlyName { get; init; }
-
-    [JsonPropertyName("icon")] public string? Icon { get; init; }
+    [JsonPropertyName("brightness")]
+    public int? Brightness { get; init; }
     
-    [JsonPropertyName("max_mireds")] public double? MaxMireds { get; init; }
+    [JsonPropertyName("color_mode")]
+    public string? ColorMode { get; init; }
 
-    [JsonPropertyName("min_mireds")] public double? MinMireds { get; init; }
+    /// <summary>
+    /// The current effect.
+    /// </summary>
+    [JsonPropertyName("effect")]
+    public string? Effect { get; init; }
+    
+    /// <summary>
+    /// The list of supported effects.
+    /// </summary>
+    [JsonPropertyName("effect_list")]
+    public IReadOnlyList<string>? EffectList { get; init; }
 
-    [JsonPropertyName("off_brightness")] public object? OffBrightness { get; init; }
+    [JsonPropertyName("friendly_name")]
+    public string? FriendlyName { get; init; }
 
+    [JsonPropertyName("icon")]
+    public string? Icon { get; init; }
+    
+    /// <summary>
+    /// The warmest color_temp that this light supports
+    /// </summary>
+    [JsonPropertyName("max_mireds")]
+    public int? MaxMireds { get; init; }
+
+    /// <summary>
+    /// The coldest color_temp that this light supports.
+    /// </summary>
+    [JsonPropertyName("min_mireds")]
+    public int? MinMireds { get; init; }
+
+    [JsonPropertyName("off_brightness")]
+    public object? OffBrightness { get; init; }
+    
     [JsonPropertyName("supported_color_modes")]
     public IReadOnlyList<string>? SupportedColorModes { get; init; }
-
-    [JsonPropertyName("supported_features")]
-    public double? SupportedFeatures { get; init; }
     
+    [JsonPropertyName("supported_features")]
+    public int? SupportedFeatures { get; init; }
+    
+    /// <summary>
+    /// Integer in mireds representing the color temperature of the light.
+    /// </summary>
     [JsonPropertyName("color_temp")]
-    public IReadOnlyList<double>? ColorTemp { get; init; }
+    public int? ColorTemp { get; init; }
 
+    /// <summary>
+    /// List containing two floats representing the hue and saturation of the color of the light. Hue is scaled 0-360, and saturation is scaled 0-100.
+    /// </summary>
     [JsonPropertyName("hs_color")]
     public IReadOnlyList<double>? HsColor { get; init; }
 
+    /// <summary>
+    /// List containing three integers between 0 and 255 representing the RGB color (red, green, blue) of the light. Three comma-separated integers that represent the color in RGB.
+    /// </summary>
     [JsonPropertyName("rgb_color")]
-    public IReadOnlyList<double>? RgbColor { get; init; }
+    public IReadOnlyList<int>? RgbColor { get; init; }
+    
+    /// <summary>
+    /// List containing four integers between 0 and 255 representing the RGBW color (red, green, blue, white) of the light. This attribute will be null for lights which do not support RGBW colors.
+    /// </summary>
+    [JsonPropertyName("rgbw_color")]
+    public IReadOnlyList<int>? RgbwColor { get; init; }
+    
+    /// <summary>
+    /// List containing five integers between 0 and 255 representing the RGBWW color (red, green, blue, cold white, warm white) of the light. This attribute will be null for lights which do not support RGBWW colors.
+    /// </summary>
+    [JsonPropertyName("rgbww_color")]
+    public IReadOnlyList<int>? RgbwwColor { get; init; }
 
+    /// <summary>
+    /// List containing two floats representing the xy color of the light. Two comma-separated floats that represent the color in XY.
+    /// </summary>
     [JsonPropertyName("xy_color")]
     public IReadOnlyList<double>? XyColor { get; init; }
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -4,7 +4,7 @@
 public record LightAttributesBase
 {
     [JsonPropertyName("entity_id")]
-    public object? EntityId { get; init; }
+    public IReadOnlyList<string>? EntityId { get; init; }
 
     /// <summary>
     /// Integer between 0 and 255 for how bright the light should be, where 0 means the light is off, 1 is the minimum brightness and 255 is the maximum brightness supported by the light.
@@ -44,9 +44,6 @@ public record LightAttributesBase
     /// </summary>
     [JsonPropertyName("min_mireds")]
     public int? MinMireds { get; init; }
-
-    [JsonPropertyName("off_brightness")]
-    public object? OffBrightness { get; init; }
     
     [JsonPropertyName("supported_color_modes")]
     public IReadOnlyList<string>? SupportedColorModes { get; init; }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -34,7 +34,7 @@ public record LightAttributesBase
     public string? Icon { get; init; }
     
     /// <summary>
-    /// The warmest color_temp that this light supports
+    /// The warmest color_temp that this light supports.
     /// </summary>
     [JsonPropertyName("max_mireds")]
     public int? MaxMireds { get; init; }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -55,37 +55,37 @@ public record LightAttributesBase
     /// The warmest color_temp that this light supports.
     /// </summary>
     [JsonPropertyName("max_mireds")]
-    public int? MaxMireds { get; init; }
+    public long? MaxMireds { get; init; }
 
     /// <summary>
     /// The coldest color_temp that this light supports.
     /// </summary>
     [JsonPropertyName("min_mireds")]
-    public int? MinMireds { get; init; }
+    public long? MinMireds { get; init; }
 
     /// <summary>
     /// List containing three integers between 0 and 255 representing the RGB color (red, green, blue) of the light. Three comma-separated integers that represent the color in RGB.
     /// </summary>
     [JsonPropertyName("rgb_color")]
-    public IReadOnlyList<int>? RgbColor { get; init; }
+    public IReadOnlyList<long>? RgbColor { get; init; }
     
     /// <summary>
     /// List containing four integers between 0 and 255 representing the RGBW color (red, green, blue, white) of the light. This attribute will be null for lights which do not support RGBW colors.
     /// </summary>
     [JsonPropertyName("rgbw_color")]
-    public IReadOnlyList<int>? RgbwColor { get; init; }
+    public IReadOnlyList<long>? RgbwColor { get; init; }
     
     /// <summary>
     /// List containing five integers between 0 and 255 representing the RGBWW color (red, green, blue, cold white, warm white) of the light. This attribute will be null for lights which do not support RGBWW colors.
     /// </summary>
     [JsonPropertyName("rgbww_color")]
-    public IReadOnlyList<int>? RgbwwColor { get; init; }
+    public IReadOnlyList<long>? RgbwwColor { get; init; }
     
     [JsonPropertyName("supported_color_modes")]
     public IReadOnlyList<string>? SupportedColorModes { get; init; }
     
     [JsonPropertyName("supported_features")]
-    public int? SupportedFeatures { get; init; }
+    public long? SupportedFeatures { get; init; }
 
     /// <summary>
     /// List containing two floats representing the xy color of the light. Two comma-separated floats that represent the color in XY.

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -1,0 +1,77 @@
+﻿namespace NetDaemon.HassModel.Entities.Core;
+#pragma warning disable CS1591
+
+public record MediaPlayerAttributesBase
+{
+    [JsonPropertyName("app_id")]
+    public string? AppId { get; init; }
+
+    [JsonPropertyName("app_name")]
+    public string? AppName { get; init; }
+
+    [JsonPropertyName("device_class")]
+    public string? DeviceClass { get; init; }
+
+    [JsonPropertyName("entity_id")]
+    public object? EntityId { get; init; }
+
+    [JsonPropertyName("entity_picture")]
+    public string? EntityPicture { get; init; }
+
+    [JsonPropertyName("entity_picture_local")]
+    public string? EntityPictureLocal { get; init; }
+
+    [JsonPropertyName("friendly_name")]
+    public string? FriendlyName { get; init; }
+
+    [JsonPropertyName("icon")]
+    public string? Icon { get; init; }
+
+    [JsonPropertyName("is_volume_muted")]
+    public bool? IsVolumeMuted { get; init; }
+
+    [JsonPropertyName("media_album_name")]
+    public string? MediaAlbumName { get; init; }
+
+    [JsonPropertyName("media_artist")]
+    public string? MediaArtist { get; init; }
+
+    [JsonPropertyName("media_content_id")]
+    public string? MediaContentId { get; init; }
+
+    [JsonPropertyName("media_content_type")]
+    public string? MediaContentType { get; init; }
+
+    [JsonPropertyName("media_duration")]
+    public double? MediaDuration { get; init; }
+
+    [JsonPropertyName("media_position")]
+    public double? MediaPosition { get; init; }
+
+    [JsonPropertyName("media_position_updated_at")]
+    public string? MediaPositionUpdatedAt { get; init; }
+
+    [JsonPropertyName("media_title")]
+    public string? MediaTitle { get; init; }
+
+    [JsonPropertyName("media_track")]
+    public double? MediaTrack { get; init; }
+
+    [JsonPropertyName("repeat")]
+    public string? Repeat { get; init; }
+
+    [JsonPropertyName("shuffle")]
+    public bool? Shuffle { get; init; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+
+    [JsonPropertyName("source_list")]
+    public IReadOnlyList<string>? SourceList { get; init; }
+
+    [JsonPropertyName("supported_features")]
+    public double? SupportedFeatures { get; init; }
+
+    [JsonPropertyName("volume_level")]
+    public double? VolumeLevel { get; init; }
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -16,15 +16,24 @@ public record MediaPlayerAttributesBase
     [JsonPropertyName("device_class")]
     public string? DeviceClass { get; init; }
 
+    /// <summary>
+    /// Entity ids of the entities in the media player group. Null if not a group.
+    /// </summary>
     [JsonPropertyName("entity_id")]
     public IReadOnlyList<string>? EntityId { get; init; }
 
+    /// <summary>
+    /// URL of the picture for the entity.
+    /// </summary>
     [JsonPropertyName("entity_picture")]
     public string? EntityPicture { get; init; }
 
     [JsonPropertyName("entity_picture_local")]
     public string? EntityPictureLocal { get; init; }
 
+    /// <summary>
+    /// Name of the media player as displayed in the UI.
+    /// </summary>
     [JsonPropertyName("friendly_name")]
     public string? FriendlyName { get; init; }
 

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace NetDaemon.HassModel.Entities.Core;
 #pragma warning disable CS1591
+#pragma warning disable CA1056
 
 public record MediaPlayerAttributesBase
 {
@@ -9,6 +10,9 @@ public record MediaPlayerAttributesBase
     [JsonPropertyName("app_name")]
     public string? AppName { get; init; }
 
+    /// <summary>
+    /// Type of media player.
+    /// </summary>
     [JsonPropertyName("device_class")]
     public string? DeviceClass { get; init; }
 
@@ -32,7 +36,20 @@ public record MediaPlayerAttributesBase
 
     [JsonPropertyName("media_album_name")]
     public string? MediaAlbumName { get; init; }
-
+    
+    /// <summary>
+    /// URL that represents the current image.
+    /// </summary>
+    [JsonPropertyName("media_image_url")]
+    public string? MediaImageUrl { get; init; }
+    
+    // This is documented but has never shown up in the forums
+    // /// <summary>
+    // /// Is the media_image_url accessible outside of the home network.
+    // /// </summary>
+    // [JsonPropertyName("media_image_remotely_accessible")]
+    // public bool? MediaImageRemotelyAccessible { get; init; }
+    
     [JsonPropertyName("media_artist")]
     public string? MediaArtist { get; init; }
 
@@ -62,16 +79,37 @@ public record MediaPlayerAttributesBase
 
     [JsonPropertyName("shuffle")]
     public bool? Shuffle { get; init; }
+    
+    /// <summary>
+    /// The current sound mode of the media player
+    /// </summary>
+    [JsonPropertyName("sound_mode")]
+    public string? SoundMode { get; init; }
+    
+    /// <summary>
+    /// Dynamic list of available sound modes (set by platform, empty means sound mode not supported)
+    /// </summary>
+    [JsonPropertyName("sound_mode_list")]
+    public IReadOnlyList<string>? SoundModeList { get; init; }
 
+    /// <summary>
+    /// The currently selected input source for the media player.
+    /// </summary>
     [JsonPropertyName("source")]
     public string? Source { get; init; }
 
+    /// <summary>
+    /// The list of possible input sources for the media player. (This list should contain human readable names, suitable for frontend display)
+    /// </summary>
     [JsonPropertyName("source_list")]
     public IReadOnlyList<string>? SourceList { get; init; }
 
     [JsonPropertyName("supported_features")]
     public double? SupportedFeatures { get; init; }
 
+    /// <summary>
+    /// Float for volume level between 0..1
+    /// </summary>
     [JsonPropertyName("volume_level")]
     public double? VolumeLevel { get; init; }
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -17,7 +17,7 @@ public record MediaPlayerAttributesBase
     public string? DeviceClass { get; init; }
 
     [JsonPropertyName("entity_id")]
-    public object? EntityId { get; init; }
+    public IReadOnlyList<string>? EntityId { get; init; }
 
     [JsonPropertyName("entity_picture")]
     public string? EntityPicture { get; init; }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -42,14 +42,7 @@ public record MediaPlayerAttributesBase
     /// </summary>
     [JsonPropertyName("media_image_url")]
     public string? MediaImageUrl { get; init; }
-    
-    // This is documented but has never shown up in the forums
-    // /// <summary>
-    // /// Is the media_image_url accessible outside of the home network.
-    // /// </summary>
-    // [JsonPropertyName("media_image_remotely_accessible")]
-    // public bool? MediaImageRemotelyAccessible { get; init; }
-    
+
     [JsonPropertyName("media_artist")]
     public string? MediaArtist { get; init; }
 

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -107,7 +107,7 @@ public record MediaPlayerAttributesBase
     public IReadOnlyList<string>? SourceList { get; init; }
 
     [JsonPropertyName("supported_features")]
-    public double? SupportedFeatures { get; init; }
+    public long? SupportedFeatures { get; init; }
 
     /// <summary>
     /// Float for volume level between 0..1

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -74,7 +74,7 @@ public record MediaPlayerAttributesBase
     public string? MediaTitle { get; init; }
 
     [JsonPropertyName("media_track")]
-    public double? MediaTrack { get; init; }
+    public object? MediaTrack { get; init; }
 
     [JsonPropertyName("repeat")]
     public string? Repeat { get; init; }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added the MediaPlayerAttributesBase class which was very simple and didn't require any other code modification. This means that I did not add any additional tests 

I partly used https://developers.home-assistant.io/docs/core/entity/media-player for reference, but excluded the `media_image_remotely_accessible` field since it never appears in the forums so it's too rare to be worth crowding the autocomplete list.

I didn't add any tests since I didn't change any code other than add the baseclass and it is working perfectly through all my testing & the existing tests all pass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: https://github.com/net-daemon/netdaemon/issues/685
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs