### PR TITLE
Add timeout to AssuredMqttConnection

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/AssuredMqttConnectionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/AssuredMqttConnectionTests.cs
@@ -15,7 +15,7 @@ public class AssuredMqttConnectionTests
         var mqttFactory = new MqttFactoryWrapper(mqttClient.Object);
        
         var conn = new AssuredMqttConnection(logger.Object, mqttFactory, GetMockOptions());
-        var returnedClient = await conn.GetClientAsync(30);
+        var returnedClient = await conn.GetClientAsync();
         
         returnedClient.Should().Be(mqttClient.Object);
     }
@@ -23,17 +23,17 @@ public class AssuredMqttConnectionTests
     [Fact]
     public async Task GetClientAbortsAfterTimeout()
     {
-        const int timeoutSeconds = 1;
+        var timeout = new TimeSpan(0, 0, 0, 0, 10);
         var logger = new Mock<ILogger<AssuredMqttConnection>>();
         
         var mqttClient = new Mock<IManagedMqttClient>();
         var mqttFactory = new MqttFactoryWrapper(mqttClient.Object);
 
         mqttClient.Setup(m => m.StartAsync(It.IsAny<ManagedMqttClientOptions>()))
-            .Callback(() => Thread.Sleep(timeoutSeconds * 2000));
+            .Callback(() => Thread.Sleep(timeout*2));
         
         var conn = new AssuredMqttConnection(logger.Object, mqttFactory, GetMockOptions());
-        var act = async () => { await conn.GetClientAsync(timeoutSeconds); };
+        var act = async () => { await conn.GetClientAsync(timeout); };
         
         await act.Should().ThrowAsync<TimeoutException>();
     }

--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/AssuredMqttConnectionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/MqttEntityManagerTests/AssuredMqttConnectionTests.cs
@@ -23,14 +23,14 @@ public class AssuredMqttConnectionTests
     [Fact]
     public async Task GetClientAbortsAfterTimeout()
     {
-        var timeout = new TimeSpan(0, 0, 0, 0, 10);
+        var timeout = TimeSpan.FromMilliseconds(5);
         var logger = new Mock<ILogger<AssuredMqttConnection>>();
         
         var mqttClient = new Mock<IManagedMqttClient>();
         var mqttFactory = new MqttFactoryWrapper(mqttClient.Object);
 
         mqttClient.Setup(m => m.StartAsync(It.IsAny<ManagedMqttClientOptions>()))
-            .Callback(() => Thread.Sleep(timeout*2));
+            .Callback(() => Thread.Sleep(TimeSpan.FromSeconds(1)));
         
         var conn = new AssuredMqttConnection(logger.Object, mqttFactory, GetMockOptions());
         var act = async () => { await conn.GetClientAsync(timeout); };

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
@@ -38,17 +38,26 @@ internal class AssuredMqttConnection : IAssuredMqttConnection, IDisposable
     /// <summary>
     /// Ensures that the MQTT client is available
     /// </summary>
-    /// <param name="timeoutSeconds">Number of seconds to wait for connection to become available</param>
+    /// <param name="timeout">Number of seconds to wait for connection to become available</param>
     /// <returns></returns>
     /// <exception cref="MqttConnectionException">Timed out while waiting for connection</exception>
-    public async Task<IManagedMqttClient> GetClientAsync(int timeoutSeconds)
+    public async Task<IManagedMqttClient> GetClientAsync(TimeSpan timeout)
     {
-        await _connectionTask.WaitAsync(new TimeSpan(0, 0, timeoutSeconds));
+        await _connectionTask.WaitAsync(timeout);
         
         if (_connectionTask.IsCompletedSuccessfully)
             return _mqttClient ?? throw new MqttConnectionException("Unable to create MQTT connection");
 
-        throw new TimeoutException($"Failed to connect to MQTT broker after {timeoutSeconds} seconds");
+        throw new TimeoutException($"Failed to connect to MQTT broker after {timeout} seconds");
+    }
+
+    /// <summary>
+    /// Ensures that the MQTT client is available
+    /// </summary>
+    /// <returns></returns>
+    public async Task<IManagedMqttClient> GetClientAsync()
+    {
+        return await GetClientAsync(new TimeSpan(0, 0, 30));
     }
 
     private async Task ConnectAsync(MqttConfiguration mqttConfig, IMqttFactoryWrapper mqttFactory)

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
@@ -44,11 +44,11 @@ internal class AssuredMqttConnection : IAssuredMqttConnection, IDisposable
     public async Task<IManagedMqttClient> GetClientAsync(TimeSpan timeout)
     {
         await _connectionTask.WaitAsync(timeout);
-        
-        if (_connectionTask.IsCompletedSuccessfully)
-            return _mqttClient ?? throw new MqttConnectionException("Unable to create MQTT connection");
 
-        throw new TimeoutException($"Failed to connect to MQTT broker after {timeout} seconds");
+        if (_connectionTask.IsCompletedSuccessfully && _mqttClient != null)
+            return _mqttClient;
+        
+        throw new MqttConnectionException("Unable to create MQTT connection");
     }
 
     /// <summary>

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/AssuredMqttConnection.cs
@@ -43,7 +43,9 @@ internal class AssuredMqttConnection : IAssuredMqttConnection, IDisposable
     /// <exception cref="MqttConnectionException">Timed out while waiting for connection</exception>
     public async Task<IManagedMqttClient> GetClientAsync(int timeoutSeconds)
     {
-        if (await Task.WhenAny(_connectionTask, Task.Delay(timeoutSeconds * 1000)) == _connectionTask)
+        await _connectionTask.WaitAsync(new TimeSpan(0, 0, timeoutSeconds));
+        
+        if (_connectionTask.IsCompletedSuccessfully)
             return _mqttClient ?? throw new MqttConnectionException("Unable to create MQTT connection");
 
         throw new TimeoutException($"Failed to connect to MQTT broker after {timeoutSeconds} seconds");

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IAssuredMqttConnection.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IAssuredMqttConnection.cs
@@ -10,5 +10,10 @@ internal interface IAssuredMqttConnection
     /// <summary>
     /// Ensures that the MQTT client is available
     /// </summary>
-    Task<IManagedMqttClient> GetClientAsync(int timeoutSeconds = 30);
+    Task<IManagedMqttClient> GetClientAsync(TimeSpan timeout);
+    
+    /// <summary>
+    /// Ensures that the MQTT client is available
+    /// </summary>
+    Task<IManagedMqttClient> GetClientAsync();
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IAssuredMqttConnection.cs
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/IAssuredMqttConnection.cs
@@ -10,5 +10,5 @@ internal interface IAssuredMqttConnection
     /// <summary>
     /// Ensures that the MQTT client is available
     /// </summary>
-    Task<IManagedMqttClient> GetClientAsync();
+    Task<IManagedMqttClient> GetClientAsync(int timeoutSeconds = 30);
 }

--- a/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
+++ b/src/Extensions/NetDaemon.Extensions.MqttEntityManager/NetDaemon.Extensions.MqttEntityManager.csproj
@@ -27,8 +27,8 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-      <PackageReference Include="MQTTnet" Version="4.1.3.436" />
-      <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.3.436" />
+      <PackageReference Include="MQTTnet" Version="4.1.4.563" />
+      <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.4.563" />
       <PackageReference Include="System.Reactive" Version="5.0.0" />
     </ItemGroup>
 

--- a/src/debug/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/src/debug/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -32,7 +32,7 @@ public class MqttEntityManagerApp : IAsyncInitializable
 #pragma warning disable 1998 // We may be debugging here, so don't block the initialize function
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
-        Task.Run(() => ExercisorAsync(cancellationToken), cancellationToken);
+        await Task.Run(() => ExercisorAsync(cancellationToken), cancellationToken);
     }
 #pragma warning disable 1998
 

--- a/src/debug/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
+++ b/src/debug/DebugHost/apps/Extensions/MqttEntityManagerApp.cs
@@ -19,7 +19,6 @@ public class MqttEntityManagerApp : IAsyncInitializable
     private readonly IHaContext _ha;
     private readonly ILogger<MqttEntityManagerApp> _logger;
     private readonly IMqttEntityManager _entityManager;
-    private Task? _exerciseTask;
 
     public MqttEntityManagerApp(IHaContext ha, ILogger<MqttEntityManagerApp> logger, IMqttEntityManager entityManager)
     {
@@ -33,7 +32,7 @@ public class MqttEntityManagerApp : IAsyncInitializable
 #pragma warning disable 1998 // We may be debugging here, so don't block the initialize function
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
-        _exerciseTask = Task.Run(() => ExercisorAsync(cancellationToken), cancellationToken);
+        Task.Run(() => ExercisorAsync(cancellationToken), cancellationToken);
     }
 #pragma warning disable 1998
 


### PR DESCRIPTION
Address potential stall scenario where AssuredMqttConnection could wait forever / a very long time to connect to MQTT.

Forced timeout of 30 seconds and added unit test to exercise the scenario.

## Non-breaking change
..._except_... in a situation where connecting to MQTT might take more than 30 seconds (which seems unlikely)

## Proposed change
Every request to the MQTT Entity Manager makes a call to the underlying `AssuredMqttConnection` class. This class sets up a reliable connection to MQTT which includes auto-reconnect.
The purpose of this class is to ensure that before we execute a fire-and-forget request to MQTT that the MQTT connection is actually in place.

Theoretically, this should be fool-proof (aha!) in that the auto-reconnect will allow for network dropouts. However a user reported that he is seeing stalls somewhere within MQTT and, as the only blocking call in the stack, this seems the most likely culprit.

So this change wraps a 30 second timeout around the return of the connection. An important point is that once a connection to a live MQTT bus is returned then this is effectively self-maintaining, with the underlying `ManagedMqttClient` handling its own reconnection to dropped destinations.

In other words, this change will abort a connection to a non-responsive MQTT but will not impact behaviour after that initial connection.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue reported in Discord

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code compiles without warnings (code quality chek)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

No user-visible changes, no documentation update needed