### PR TITLE
Add deviceId to Entity class and codegen

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EntitiesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EntitiesGenerator.cs
@@ -79,7 +79,7 @@ internal static class EntitiesGenerator
     {
         var entityName = EntityIdHelper.GetEntity(entity.id);
 
-        var propertyCode = $@"{className} {entityName.ToNormalizedPascalCase((string)"E_")} => new(_{GetNames<IHaContext>().VariableName}, ""{entity.id}"");";
+        var propertyCode = $@"{className} {entityName.ToNormalizedPascalCase((string)"E_")} => new(_{GetNames<IHaContext>().VariableName}, ""{entity.id}"", ""{entity.deviceId}"");";
 
         var name = entity.friendlyName;
         return ParseProperty(propertyCode).ToPublic().WithSummaryComment(name);
@@ -100,7 +100,7 @@ internal static class EntitiesGenerator
         var (className, variableName) = GetNames<IHaContext>();
         var classDeclaration = $@"record {domainMetaData.EntityClassName} : {baseClass}
                                     {{
-                                            public {domainMetaData.EntityClassName}({className} {variableName}, string entityId) : base({variableName}, entityId)
+                                            public {domainMetaData.EntityClassName}({className} {variableName}, string entityId, string? deviceId = null) : base({variableName}, entityId, deviceId)
                                             {{}}
 
                                             public {domainMetaData.EntityClassName}({SimplifyTypeName(typeof(Entity))} entity) : base(entity)

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Controller.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Controller.cs
@@ -27,10 +27,10 @@ internal class Controller
     
     public async Task RunAsync()
     {
-        var (hassStates, servicesMetaData) = await HaRepositry.GetHaData(_haSettings).ConfigureAwait(false);
+        var (hassStates, hassEntities, servicesMetaData) = await HaRepositry.GetHaData(_haSettings).ConfigureAwait(false);
 
         var previousEntityMetadata = await LoadEntitiesMetaDataAsync().ConfigureAwait(false);
-        var currentEntityMetaData = EntityMetaDataGenerator.GetEntityDomainMetaData(hassStates);
+        var currentEntityMetaData = EntityMetaDataGenerator.GetEntityDomainMetaData(hassStates, hassEntities);
         var mergedEntityMetaData = EntityMetaDataMerger.Merge(_generationSettings, previousEntityMetadata, currentEntityMetaData);
 
         await Save(mergedEntityMetaData, EntityMetaDataFileName).ConfigureAwait(false);

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/HaRepositry.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/HaRepositry.cs
@@ -12,7 +12,7 @@ namespace NetDaemon.HassModel.CodeGenerator;
 
 internal static class HaRepositry
 {
-    public record HaData(IReadOnlyCollection<HassState> states, JsonElement? servicesMetaData);
+    public record HaData(IReadOnlyCollection<HassState> states, IReadOnlyCollection<HassEntity> entities, JsonElement? servicesMetaData);
 
     public static async Task<HaData> GetHaData(HomeAssistantSettings homeAssistantSettings)
     {
@@ -31,8 +31,9 @@ internal static class HaRepositry
         {
             var services = await connection.GetServicesAsync(CancellationToken.None).ConfigureAwait(false);
             var states = await connection.GetStatesAsync(CancellationToken.None).ConfigureAwait(false);
+            var entities = await connection.GetEntitiesAsync(CancellationToken.None).ConfigureAwait(false);
 
-            return new HaData(states!, services);
+            return new HaData(states!, entities!, services);
         }
     }
 

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityDomainMetadata.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityDomainMetadata.cs
@@ -33,6 +33,6 @@ record EntityDomainMetadata(
     public Type? AttributesBaseClass { get; set; }
 };
 
-record EntityMetaData(string id, string? friendlyName);
+record EntityMetaData(string id, string? friendlyName, string? deviceId = null);
 
 record EntityAttributeMetaData(string JsonName, string CSharpName, Type ClrType);

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaDataGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaDataGenerator.cs
@@ -7,26 +7,28 @@ internal static class EntityMetaDataGenerator
     /// <summary>
     /// Creates metadata describing entities and their attributes based on all the states from HA 
     /// </summary>
-    public static EntitiesMetaData GetEntityDomainMetaData(IReadOnlyCollection<HassState> entityStates)
+    public static EntitiesMetaData GetEntityDomainMetaData(IReadOnlyCollection<HassState> entityStates, IReadOnlyCollection<HassEntity> entities)
     {
         // We need to group the entities by domain, because some domains (Sensor) have numeric and non numeric
         // entities that should be treated differently we also group by IsNumeric
         var domainGroups = entityStates.GroupBy(e => (domain: EntityIdHelper.GetDomain(e.EntityId), isNumeric: IsNumeric(e)));
 
+        var entityToDeviceDict = entities.ToDictionary(k => k.EntityId!, v => v.DeviceId);
+
         return new EntitiesMetaData{Domains = domainGroups.OrderBy(g => g.Key)
-            .Select(mapEntityDomainMetadata)
+            .Select(e => mapEntityDomainMetadata(e, entityToDeviceDict))
             .ToList()};
     }
 
-    private static EntityDomainMetadata mapEntityDomainMetadata(IGrouping<(string domain, bool isNumeric), HassState> domainGroup) =>
+    private static EntityDomainMetadata mapEntityDomainMetadata(IGrouping<(string domain, bool isNumeric), HassState> domainGroup, Dictionary<string, string?> entityToDeviceDict) =>
         new (
             Domain: domainGroup.Key.domain, 
             IsNumeric: domainGroup.Key.isNumeric, 
-            Entities: MapToEntityMetaData(domainGroup),
+            Entities: MapToEntityMetaData(domainGroup, entityToDeviceDict),
             Attributes: AttributeMetaDataGenerator.GetMetaDataFromEntityStates(domainGroup).ToList());
 
-    private static List<EntityMetaData> MapToEntityMetaData(IEnumerable<HassState> g) =>
-        g.Select(state => new EntityMetaData(state.EntityId, GetFriendlyName(state)))
+    private static List<EntityMetaData> MapToEntityMetaData(IEnumerable<HassState> g, Dictionary<string, string?> entityToDeviceDict) =>
+        g.Select(state => new EntityMetaData(state.EntityId, GetFriendlyName(state), entityToDeviceDict.GetValueOrDefault(state.EntityId, null)))
             .OrderBy(s=>s.id).ToList();
 
     private static string? GetFriendlyName(HassState hassState) => hassState.AttributesAs<Attributes>()?.friendly_name;

--- a/src/HassModel/NetDeamon.HassModel/Entities/Entity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Entity.cs
@@ -14,14 +14,21 @@ public record Entity
     public string EntityId { get; }
 
     /// <summary>
+    /// Device id of the device associated with this entity
+    /// </summary>
+    public string? DeviceId { get; }
+
+    /// <summary>
     /// Creates a new instance of a Entity class
     /// </summary>
     /// <param name="haContext">The Home Assistant context associated with this Entity</param>
     /// <param name="entityId">The id of this Entity</param>
-    public Entity(IHaContext haContext, string entityId)
+    /// <param name="deviceId">The id of the device associated with this entity</param>
+    public Entity(IHaContext haContext, string entityId, string? deviceId = null)
     {
         HaContext = haContext;
         EntityId = entityId;
+        DeviceId = deviceId;
     }
         
     /// <summary>
@@ -82,7 +89,7 @@ public abstract record Entity<TEntity, TEntityState, TAttributes> : Entity
     { }
 
     /// <summary>Constructor from haContext and entityId</summary>
-    protected Entity(IHaContext haContext, string entityId) : base(haContext, entityId)
+    protected Entity(IHaContext haContext, string entityId, string? deviceId = null) : base(haContext, entityId, deviceId)
     { }
 
     /// <inheritdoc />

--- a/src/HassModel/NetDeamon.HassModel/Entities/NumericEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/NumericEntity.cs
@@ -39,7 +39,7 @@ public record NumericEntity<TEntity, TEntityState, TAttributes> : Entity<TEntity
     public NumericEntity(Entity entity) : base(entity) { }
 
     /// <summary>Constructor from haContext and entityId</summary>
-    public NumericEntity(IHaContext haContext, string entityId) : base(haContext, entityId) { }
+    public NumericEntity(IHaContext haContext, string entityId, string? deviceId = null) : base(haContext, entityId, deviceId) { }
         
     /// <summary>The current state of this Entity converted to double if possible, null if it is not</summary>
     public new double? State => EntityState?.State;
@@ -69,5 +69,5 @@ public record NumericEntity<TAttributes> : NumericEntity<NumericEntity<TAttribut
     public NumericEntity(Entity entity) : base(entity) { }
     
     /// <summary>Constructor from haContext and entityId</summary>
-    public NumericEntity(IHaContext haContext, string entityId) : base(haContext, entityId) { }
+    public NumericEntity(IHaContext haContext, string entityId, string? deviceId = null) : base(haContext, entityId, deviceId) { }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the DeviceId property to the Entity class and updates the Code Generator to populate all entities with the DeviceId of their associated device.

A future enhancement could augment the existing EntityAreaCache code to also track the device registry, which is mutable in Home Assistant. Since the DeviceId associated with an entity will never change, it makes sense to bake it into the Entity class.

The immediate benefit is that users can now access the DeviceId of their devices via the DeviceId property of any of the associated entities. A specific use case is listening for the "zwave_js_value_notification" event for a specific device.

I have marked the PR as "draft" because it is as yet untested beyond running the test suite, and I've only added a single test so far. Before putting in the real work, I want to gather feedback on whether this enhancement acceptable before I put in the real testing work.

Side note: I considered whether it would be a good idea to add other properties such as AreaId to the codegen, but I think that only truly immutable properties should be baked in. An entity might change areas, get renamed, etc., but the DeviceId should never change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs