### PR TITLE
Add an entity model that support generic state types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
         "noquotes",
         "parentidguid",
         "useridguid"
-    ]
+    ],
+    "dotnet-test-explorer.testProjectPath": "**/*Tests.@(csproj|vbproj|fsproj)"
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/GlobalEntityUsings.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/GlobalEntityUsings.cs
@@ -1,0 +1,1 @@
+global using TestLightEntity = NetDaemon.HassModel.Entities.IEntity<string?, NetDaemon.HassModel.Tests.Entities.LightAttributes>;

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityDomainServiceExtensionsTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityDomainServiceExtensionsTest.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using NetDaemon.Client.HomeAssistant.Model;
+using NetDaemon.HassModel.Entities;
+using NetDaemon.HassModel.Tests.TestHelpers;
+using NetDaemon.HassModel.Tests.TestHelpers.HassClient;
+
+namespace NetDaemon.HassModel.Tests.Entities;
+
+// Sample code to create with code generator
+//
+// This was put together in a rush to demonstrate the technique. I didn't reference the format required for the data parameter in CallService,
+// so this is almost certainly an invalid call, but it should demonstrate the technique. I'll clean up and broaden all these test in the coming
+// days as my time frees up.
+//
+// The basic idea for the code generator is to create extension methods on Attributes type. I believe that this is very similar to the current behavior.
+public record LightAttributes([property:JsonPropertyName("brightness")]double? Brightness);
+
+public static class LightServiceExtensions
+{
+    public static void TurnOn<TState>(this IEntity<TState, LightAttributes> light, double? brightness = null) => light.CallService("turn_on", brightness);
+}
+
+public class IEntityDomainServiceExtensionsTest
+{
+    public IEntityStateMapper<double?, LightAttributes> LightMapper = DefaultEntityStateMappers.NumericTypedAttributes<LightAttributes>();
+    
+    [Fact]
+    public void CanCallDomainServiceOnStateChange()
+    {
+        // Arrange
+        var entityId = "light.one";
+        var haContextMock = new Mock<IHaContext>();
+        var hassStateChangesSubject = new Subject<HassStateChangedEventData>();
+        haContextMock.Setup(h => h.HassStateAllChanges()).Returns(hassStateChangesSubject);
+
+        var lightEntity = LightMapper.Entity(haContextMock.Object, entityId);
+        var brightness = 50d;
+
+        // Act
+        lightEntity.StateChanges().Subscribe(e => e.Entity.TurnOn(brightness: brightness));
+
+        hassStateChangesSubject.OnNext(
+            new HassStateChangedEventData
+            {
+                EntityId = entityId,
+                NewState = new HassState
+                    {
+                        EntityId = entityId,
+                        State = "off"
+                    },
+                OldState = new HassState
+                    {
+                        EntityId = entityId,
+                        State = "on"
+                    }
+            });
+
+        // Assert
+        haContextMock.Verify(h => h.CallService("light", "turn_on", It.Is<ServiceTarget>(t => t.EntityIds!.Single() == lightEntity.EntityId), brightness), Times.Once);
+    }
+}

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
@@ -126,6 +126,8 @@ public class IEntityTest
         var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
         entity.State.Should().Be("12.3");
 
+        entity.WithStateAs(s => s);
+
         // Act: AsNumeric
         var numericEntity = entity.AsNumeric();
 

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
@@ -250,6 +250,27 @@ public class IEntityTest
         stateAllChangeObserverMock.VerifyNoOtherCalls();
     }
 
+    [Fact]
+    public void StatePropertyShouldBeCultureUnaware()
+    {
+        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("De-de");
+
+        var entityId = "sensor.temperature";
+
+        var haContextMock = new HaContextMock();
+        haContextMock.Setup(m => m.GetHassState(entityId)).Returns(new HassState { EntityId = entityId, State = "12.5" });
+
+        var entity = new EntityGenericFactory(haContextMock.Object).CreateIEntity(entityId, DefaultEntityStateMappers.Base);
+
+        var numericEntity = entity.AsNumeric();
+        numericEntity.State.Should().Be(12.5);
+        numericEntity.EntityState!.State.Should().Be(12.5);
+
+        var withAttributesAs = entity.MappedBy(DefaultEntityStateMappers.NumericTypedAttributes<TestSensorAttributes>());
+        withAttributesAs.State.Should().Be(12.5);
+        withAttributesAs.EntityState!.State.Should().Be(12.5);
+    }
+
     // Attribute records
     public record AttributesWithName([property:JsonPropertyName("name")]string? Name);
     public record TestSensorAttributes([property:JsonPropertyName("set_point")]double? SetPoint, [property:JsonPropertyName("units")]string? Units);

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
@@ -1,0 +1,296 @@
+using System.Globalization;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading;
+using NetDaemon.HassModel.Entities;
+using NetDaemon.HassModel.Tests.TestHelpers;
+using NetDaemon.HassModel.Tests.TestHelpers.HassClient;
+
+namespace NetDaemon.HassModel.Tests.Entities;
+
+public class IEntityTest
+{
+    [Fact]
+    public void ShouldWrapStateFromHaContext()
+    {
+        // Arrange
+        var entityId = "domain.testEntity";
+
+        var haContextMock = new Mock<IHaContext>();
+
+        var entityState =
+            new EntityStateGeneric
+            (
+                entityId,
+                "CurrentState",
+                new { name = "FirstName" }.AsJsonElement()
+            );
+
+        haContextMock.Setup(t => t.GetStateGeneric(entityId)).Returns(entityState);
+
+        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+
+        // Act
+        var target = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
+
+        // Assert
+        target.State.Should().Be("CurrentState");
+        target.Attributes!.Name.Should().Be("FirstName");
+
+        target.EntityState!.State.Should().Be("CurrentState");
+        target.EntityState!.Attributes!.Name.Should().Be("FirstName");
+
+        // Act2: update the state
+        var newEntityState =
+            new EntityStateGeneric
+            (
+                entityId,
+                "NewState",
+                new { name = "SecondName" }.AsJsonElement()
+            );
+
+        haContextMock.Setup(t => t.GetStateGeneric(entityId)).Returns(newEntityState);
+
+        // Assert
+        target.State.Should().Be("NewState");
+        target.Attributes!.Name.Should().Be("SecondName");
+
+        target.EntityState!.State.Should().Be("NewState");
+        target.EntityState!.Attributes!.Name.Should().Be("SecondName");
+    }
+
+    [Fact]
+    public void ShouldShowStateChangesFromContext()
+    {
+        var entityId = "domain.testEntity";
+        var stateChangesSubject = new Subject<IStateChange>();
+        var haContextMock = new Mock<IHaContext>();
+        haContextMock.Setup(h => h.StateAllChangesGeneric()).Returns(stateChangesSubject);
+        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+
+        var target = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
+        var stateChangeObserverMock = new Mock<IObserver<IStateChange>>();
+        var stateAllChangeObserverMock = new Mock<IObserver<IStateChange>>();
+
+        target.StateAllChanges().Subscribe(stateAllChangeObserverMock.Object);
+        target.StateChanges().Subscribe(stateChangeObserverMock.Object);
+
+        stateChangesSubject.OnNext(
+            new StateChangeGeneric
+            (
+                target,
+                new EntityStateGeneric(entityId, "old"),
+                new EntityStateGeneric(entityId, "new")
+            ));
+
+        stateChangesSubject.OnNext(
+            new StateChangeGeneric
+            (
+                target,
+                new EntityStateGeneric(entityId, "same"),
+                new EntityStateGeneric(entityId, "same")
+            ));
+
+        stateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Once);
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void ShouldCallServiceOnContext()
+    {
+        var entityId = "domain.testEntity";
+        var haContextMock = new Mock<IHaContext>();
+        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+
+        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
+        var data = "payload";
+
+        entity.CallService("service", data);
+
+        haContextMock.Verify(h => h.CallService("domain", "service", It.Is<ServiceTarget>(t => t.EntityIds!.Single() == entity.EntityId), data), Times.Once);
+    }
+
+    [Fact]
+    public void AsNumeric_Than_WithAttributesAs()
+    {
+        var entityId = "sensor.temperature";
+
+        var haContextMock = new HaContextMock();
+        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(
+            new EntityStateGeneric(entityId, "12.3", JsonSerializer.Deserialize<JsonElement>(@"{""setPoint"": 21.5, ""units"": ""Celcius""}"))
+        );
+
+        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+
+        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
+        entity.State.Should().Be("12.3");
+
+        // Act: AsNumeric
+        var numericEntity = entity.AsNumeric();
+
+        // Assert
+        numericEntity.State!.Value!.Should().Be(12.3d);
+        numericEntity.EntityState!.State!.Value!.Should().Be(12.3d);
+        numericEntity.StateAllChanges().Where(e => e.New?.State > 1.2);
+        // Act: WithNewAttributesAs
+        var withAttributes = numericEntity.WithAttributesAs<TestSensorAttributes>();
+
+        // Assert
+        withAttributes.State!.Value!.Should().Be(12.3d);
+        withAttributes.EntityState!.State!.Value!.Should().Be(12.3d);
+
+        withAttributes.Attributes!.units.Should().Be("Celcius");
+        withAttributes.Attributes!.setPoint.Should().Be(21.5);
+        withAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
+        withAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
+        withAttributes.StateAllChanges().Where(e => e.New?.State > 1.2 && e.Entity != null);
+
+    }
+
+    [Fact]
+    public void WithAttributesAs_Than_AsNumeric()
+    {
+        var entityId = "sensor.temperature";
+
+        var haContextMock = new HaContextMock();
+        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(
+            new EntityStateGeneric(entityId, "12.3", JsonSerializer.Deserialize<JsonElement>(@"{""setPoint"": 21.5, ""units"": ""Celcius""}"))
+        );
+
+        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.Base);
+
+        // Act: WithAttributesAs
+        IEntity<string?, TestSensorAttributes> withAttributes = entity.WithAttributesAs<TestSensorAttributes>();
+        IEntity<double?, TestSensorAttributes> numericEntity = withAttributes.AsNumeric();
+
+        // Assert
+        withAttributes.State.Should().Be("12.3", because: "State  is still a string");
+
+        withAttributes.Attributes!.units.Should().Be("Celcius");
+        withAttributes.Attributes!.setPoint.Should().Be(21.5);
+        withAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
+        withAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
+
+        // Act: AsNumeric() 
+        var numericWithAttributes = withAttributes.AsNumeric();
+
+        numericWithAttributes.State!.Value!.Should().Be(12.3d);
+        numericWithAttributes.EntityState!.State!.Value!.Should().Be(12.3d);
+
+        numericWithAttributes.Attributes!.units.Should().Be("Celcius");
+        numericWithAttributes.Attributes!.setPoint.Should().Be(21.5);
+        numericWithAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
+        numericWithAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
+
+        haContextMock.StateAllChangeGenericSubject.OnNext(new StateChangeGeneric(entity, new EntityStateGeneric(entity.EntityId), new EntityStateGeneric(entity.EntityId)));
+        numericWithAttributes.StateAllChanges().Where(e => e.New?.State > 1.2 && e.Entity != null).Subscribe();
+
+    }
+
+    record TestSensorAttributes(double setPoint, string units);
+
+    [Fact]
+    public void NumericShouldShowStateChangesFromContext()
+    {
+        var haContextMock = new HaContextMock();
+
+        var entity = new Entity(haContextMock.Object, "domain.testEntity");
+        var target = new NumericEntity(entity);
+
+        haContextMock.Setup(m => m.GetState(entity.EntityId)).Returns(new EntityState() { State = "3.14" });
+
+        var stateAllChangeObserverMock = target.StateAllChanges().SubscribeMock();
+        var stateChangeObserverMock = target.StateChanges().SubscribeMock();
+
+        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
+            old: new EntityState { State = "1" },
+            @new: new EntityState { State = "1" }));
+
+        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
+            old: new EntityState { State = "1" },
+            @new: new EntityState { State = "2" }));
+
+        // Assert
+        stateChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+        stateChangeObserverMock.VerifyNoOtherCalls();
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(1.0))), Times.Once);
+        stateAllChangeObserverMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void GenericNumericEntityShouldShowStateChangesFromContext()
+    {
+        // Arrange
+        var haContextMock = new HaContextMock();
+
+        var entity = new Entity(haContextMock.Object, "domain.testEntity");
+        var target = new NumericTestEntity(entity);
+
+        var stateChangeObserverMock = target.StateChanges().SubscribeMock();
+        var stateAllChangeObserverMock = target.StateAllChanges().SubscribeMock();
+
+        haContextMock.Setup(m => m.GetState(entity.EntityId)).Returns(new EntityState() { State = "3.14" });
+
+        // Act
+        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
+            old: new EntityState { State = "1" },
+            @new: new EntityState { State = "1" }));
+
+        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
+            old: new EntityState { State = "1" },
+            @new: new EntityState { State = "2" }));
+
+        // Assert
+        stateChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+        stateChangeObserverMock.VerifyNoOtherCalls();
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(1.0))), Times.Once);
+        stateAllChangeObserverMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void StatePropertyShouldBeCultureUnaware()
+    {
+        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("De-de");
+
+        var entityId = "sensor.temperature";
+
+        var haContextMock = new HaContextMock();
+        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(new EntityStateGeneric(entityId, "12.5"));
+
+        var entity = new EntityGenericFactory(haContextMock.Object).CreateIEntity(entityId, DefaultEntityStateMappers.Base);
+
+        var numericEntity = entity.AsNumeric();
+        numericEntity.State.Should().Be(12.5);
+        numericEntity.EntityState!.State.Should().Be(12.5);
+
+        var withAttributesAs = numericEntity.WithAttributesAs<TestEntityAttributes>();
+        withAttributesAs.State.Should().Be(12.5);
+        withAttributesAs.EntityState!.State.Should().Be(12.5);
+    }
+}

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -39,9 +40,24 @@ public class IEntityTest
 
         target.EntityState!.State.Should().Be("state initial");
         target.EntityState!.Attributes!.Name.Should().Be("name initial");
-    }
 
-    public record AttributesWithName([property:JsonPropertyName("name")]string? Name);
+        // Act2: update the state
+        var newHassState = new HassState
+            {
+                EntityId = entityId,
+                State = "NewState",
+                AttributesJson = new { name = "SecondName" }.AsJsonElement()
+            };
+
+        haContextMock.Setup(t => t.GetHassState(entityId)).Returns(newHassState);
+
+        // Assert
+        target.State.Should().Be("NewState");
+        target.Attributes!.Name.Should().Be("SecondName");
+
+        target.EntityState!.State.Should().Be("NewState");
+        target.EntityState!.Attributes!.Name.Should().Be("SecondName");
+    }
 
     [Fact]
     public void ShouldShowStateChangesFromContext()
@@ -61,7 +77,6 @@ public class IEntityTest
         haContextMock.Setup(t => t.GetHassState(It.IsAny<string>())).Returns(hassState);
 
         haContextMock.Setup(h => h.HassStateAllChanges()).Returns(hassStateChangesSubject);
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
 
         var target = mapper.Entity(haContextMock.Object, entityId);
         var stateChangeObserverMock = new Mock<IObserver<IStateChange<string?, AttributesWithName>>>();
@@ -105,4 +120,137 @@ public class IEntityTest
         stateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange<string?, AttributesWithName>>()), Times.Once);
         stateAllChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange<string?, AttributesWithName>>()), Times.Exactly(2));
     }
+
+    [Fact]
+    public void ShouldCallServiceOnContext()
+    {
+        var entityId = "domain.testEntity";
+        var haContextMock = new Mock<IHaContext>();
+        var mapper = DefaultEntityStateMappers.TypedAttributes<AttributesWithName>();
+
+        var entity = mapper.Entity(haContextMock.Object, entityId);
+        var data = "payload";
+
+        entity.CallService("service", data);
+
+        haContextMock.Verify(h => h.CallService("domain", "service", It.Is<ServiceTarget>(t => t.EntityIds!.Single() == entity.EntityId), data), Times.Once);
+    }
+
+    [Fact]
+    public void AsNumericThanWithAttributesAs()
+    {
+        var entityId = "sensor.temperature";
+        var haContextMock = new HaContextMock();
+        haContextMock.Setup(m => m.GetHassState(entityId)).Returns(
+            new HassState {
+                EntityId = entityId,
+                State = "12.3",
+                AttributesJson = new { set_point = 21.5, units = "Celcius"}.AsJsonElement()
+            }
+        );
+        var hassStateChangesSubject = new Subject<HassStateChangedEventData>();
+        haContextMock.Setup(h => h.HassStateAllChanges()).Returns(hassStateChangesSubject);
+        
+        var baseMapper = DefaultEntityStateMappers.Base;
+
+        var entity = baseMapper.Entity(haContextMock.Object, entityId);
+        entity.State.Should().Be("12.3");
+
+        // Act: AsNumeric
+        var numericEntity = entity.AsNumeric();
+
+        // Assert
+        numericEntity.State!.Value!.Should().Be(12.3d);
+        numericEntity.EntityState!.State!.Value!.Should().Be(12.3d);
+        numericEntity.StateAllChanges().Where(e => e.New?.State > 1.2);
+
+        // Act: WithNewAttributesAs
+        var numericWithAttributesMapper = DefaultEntityStateMappers.NumericTypedAttributes<TestSensorAttributes>();
+        var withAttributes = numericWithAttributesMapper.Map(numericEntity);
+        withAttributes.StateAllChanges().Where(e => e.New?.State > 1.2 && e.Entity != null);
+        var stateChangeObserverMock = new Mock<IObserver<IStateChange<double?, TestSensorAttributes>>>();
+        var conditionalStateChangeObserverMock = new Mock<IObserver<IStateChange<double?, TestSensorAttributes>>>();
+
+        // Assert
+        withAttributes.State!.Value!.Should().Be(12.3d);
+        withAttributes.EntityState!.State!.Value!.Should().Be(12.3d);
+
+        withAttributes.Attributes!.Units.Should().Be("Celcius");
+        withAttributes.Attributes!.SetPoint.Should().Be(21.5);
+        withAttributes.EntityState!.Attributes!.Units.Should().Be("Celcius");
+        withAttributes.EntityState!.Attributes!.SetPoint.Should().Be(21.5);
+        withAttributes.StateAllChanges().Subscribe(stateChangeObserverMock.Object);
+        withAttributes.StateAllChanges().Where(e => e.New?.State > 7.2 && e.Entity != null).Subscribe(conditionalStateChangeObserverMock.Object);
+        hassStateChangesSubject.OnNext(
+            new HassStateChangedEventData
+            {
+                EntityId = entityId,
+                NewState = new HassState
+                    {
+                        EntityId = entityId,
+                        State = "1.5"
+                    },
+                OldState = new HassState
+                    {
+                        EntityId = entityId,
+                        State = "21.5"
+                    }
+            });
+        stateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange<double?, TestSensorAttributes>>()), Times.Once);
+        conditionalStateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange<double?, TestSensorAttributes>>()), Times.Never);
+    }
+
+    [Fact]
+    public void NumericShouldShowStateChangesFromContext()
+    {
+        var haContextMock = new HaContextMock();
+        var entityId = "domain.testEntity";
+        var mapper = DefaultEntityStateMappers.NumericBase;
+
+        var target = mapper.Entity(haContextMock.Object, entityId);
+
+        haContextMock.Setup(m => m.GetHassState(entityId)).Returns(new HassState() { EntityId = entityId, State = "3.14" });
+
+        var hassStateAllChangesSubject = new Subject<HassStateChangedEventData>();
+        haContextMock.Setup(h => h.HassStateAllChanges()).Returns(hassStateAllChangesSubject);
+
+        var stateAllChangeObserverMock = target.StateAllChanges().SubscribeMock();
+        var stateChangeObserverMock = target.StateChanges().SubscribeMock();
+
+        hassStateAllChangesSubject.OnNext(new HassStateChangedEventData
+                {
+                    EntityId = entityId,
+                    OldState = new HassState { EntityId = entityId, State = "1" },
+                    NewState = new HassState { EntityId = entityId, State = "1" }
+                });
+
+        hassStateAllChangesSubject.OnNext(new HassStateChangedEventData
+                {
+                    EntityId = entityId,
+                    OldState = new HassState { EntityId = entityId, State = "1" },
+                    NewState = new HassState { EntityId = entityId, State = "2" }
+                });
+
+        // Assert
+        stateChangeObserverMock.Verify(o => o.OnNext(It.Is<IStateChange<double?, Dictionary<string, object>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+        stateChangeObserverMock.VerifyNoOtherCalls();
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<IStateChange<double?, Dictionary<string, object>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(2.0))), Times.Once);
+
+        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<IStateChange<double?, Dictionary<string, object>>>
+        (e => e.Entity.State.Equals(3.14) &&
+              e.Old!.State.Equals(1.0) &&
+              e.New!.State.Equals(1.0))), Times.Once);
+        stateAllChangeObserverMock.VerifyNoOtherCalls();
+    }
+
+    // Attribute records
+    public record AttributesWithName([property:JsonPropertyName("name")]string? Name);
+    public record TestSensorAttributes([property:JsonPropertyName("set_point")]double? SetPoint, [property:JsonPropertyName("units")]string? Units);
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/IEntities/IEntityTest.cs
@@ -2,7 +2,9 @@ using System.Globalization;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
+using NetDaemon.Client.HomeAssistant.Model;
 using NetDaemon.HassModel.Entities;
 using NetDaemon.HassModel.Tests.TestHelpers;
 using NetDaemon.HassModel.Tests.TestHelpers.HassClient;
@@ -12,287 +14,79 @@ namespace NetDaemon.HassModel.Tests.Entities;
 public class IEntityTest
 {
     [Fact]
-    public void ShouldWrapStateFromHaContext()
+    public void ShouldGetStateFromHaContext()
     {
-        // Arrange
-        var entityId = "domain.testEntity";
-
+        // ARRANGE
         var haContextMock = new Mock<IHaContext>();
+        var entityId = "domain.test_entity";
+        var mapper = DefaultEntityStateMappers.TypedAttributes<AttributesWithName>();
 
-        var entityState =
-            new EntityStateGeneric
-            (
-                entityId,
-                "CurrentState",
-                new { name = "FirstName" }.AsJsonElement()
-            );
+        var hassState = new HassState
+            {
+                EntityId = entityId,
+                State = "state initial",
+                AttributesJson = new { name = "name initial" }.AsJsonElement()
+            };
 
-        haContextMock.Setup(t => t.GetStateGeneric(entityId)).Returns(entityState);
+        haContextMock.Setup(t => t.GetState(It.IsAny<string>(), It.IsAny<Func<HassState?, IEntityState<string?, AttributesWithName>?>>())).Returns(mapper.MapHassState(hassState));
+        
+        // ACT
+        var target = mapper.Entity(haContextMock.Object, entityId);
+       
+        // ASSERT
+        target.State.Should().Be("state initial");
+        target.Attributes!.Name.Should().Be("name initial");
 
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
-
-        // Act
-        var target = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
-
-        // Assert
-        target.State.Should().Be("CurrentState");
-        target.Attributes!.Name.Should().Be("FirstName");
-
-        target.EntityState!.State.Should().Be("CurrentState");
-        target.EntityState!.Attributes!.Name.Should().Be("FirstName");
-
-        // Act2: update the state
-        var newEntityState =
-            new EntityStateGeneric
-            (
-                entityId,
-                "NewState",
-                new { name = "SecondName" }.AsJsonElement()
-            );
-
-        haContextMock.Setup(t => t.GetStateGeneric(entityId)).Returns(newEntityState);
-
-        // Assert
-        target.State.Should().Be("NewState");
-        target.Attributes!.Name.Should().Be("SecondName");
-
-        target.EntityState!.State.Should().Be("NewState");
-        target.EntityState!.Attributes!.Name.Should().Be("SecondName");
+        target.EntityState!.State.Should().Be("state initial");
+        target.EntityState!.Attributes!.Name.Should().Be("name initial");
     }
 
-    [Fact]
-    public void ShouldShowStateChangesFromContext()
-    {
-        var entityId = "domain.testEntity";
-        var stateChangesSubject = new Subject<IStateChange>();
-        var haContextMock = new Mock<IHaContext>();
-        haContextMock.Setup(h => h.StateAllChangesGeneric()).Returns(stateChangesSubject);
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+    record AttributesWithName([property:JsonPropertyName("name")]string? Name);
 
-        var target = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
-        var stateChangeObserverMock = new Mock<IObserver<IStateChange>>();
-        var stateAllChangeObserverMock = new Mock<IObserver<IStateChange>>();
+    // [Fact]
+    // public void ShouldShowStateChangesFromContext()
+    // {
+    //     var haContextMock = new Mock<IHaContext>();
+    //     var stateChangesSubject = new Subject<IStateChange<string, AttributesWithName>>();
+    //     var entityId = "domain.test_entity";
+    //     var mapper = DefaultEntityStateMappers.TypedAttributes<AttributesWithName>();
 
-        target.StateAllChanges().Subscribe(stateAllChangeObserverMock.Object);
-        target.StateChanges().Subscribe(stateChangeObserverMock.Object);
+    //     var hassState = new HassState
+    //         {
+    //             EntityId = entityId,
+    //             State = "state initial",
+    //             AttributesJson = new { name = "name initial" }.AsJsonElement()
+    //         };
 
-        stateChangesSubject.OnNext(
-            new StateChangeGeneric
-            (
-                target,
-                new EntityStateGeneric(entityId, "old"),
-                new EntityStateGeneric(entityId, "new")
-            ));
+    //     haContextMock.Setup(t => t.GetState(It.IsAny<string>(), It.IsAny<Func<HassState?, IEntityState<string?, AttributesWithName>?>>())).Returns(mapper.MapHassState(hassState));
 
-        stateChangesSubject.OnNext(
-            new StateChangeGeneric
-            (
-                target,
-                new EntityStateGeneric(entityId, "same"),
-                new EntityStateGeneric(entityId, "same")
-            ));
+    //     haContextMock.Setup(h => h.StateAllChangesGeneric(It.IsAny<Func<HassStateChangedEventData, IStateChange<string?, AttributesWithName>>>)).Returns(stateChangesSubject);
+    //     var entityFactory = new EntityGenericFactory(haContextMock.Object);
 
-        stateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Once);
-        stateAllChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Exactly(2));
-    }
+    //     var target = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<AttributesWithName>());
+    //     var stateChangeObserverMock = new Mock<IObserver<IStateChange>>();
+    //     var stateAllChangeObserverMock = new Mock<IObserver<IStateChange>>();
 
-    [Fact]
-    public void ShouldCallServiceOnContext()
-    {
-        var entityId = "domain.testEntity";
-        var haContextMock = new Mock<IHaContext>();
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
+    //     target.StateAllChanges().Subscribe(stateAllChangeObserverMock.Object);
+    //     target.StateChanges().Subscribe(stateChangeObserverMock.Object);
 
-        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
-        var data = "payload";
+    //     stateChangesSubject.OnNext(
+    //         new StateChangeGeneric
+    //         (
+    //             target,
+    //             new EntityStateGeneric(entityId, "old"),
+    //             new EntityStateGeneric(entityId, "new")
+    //         ));
 
-        entity.CallService("service", data);
+    //     stateChangesSubject.OnNext(
+    //         new StateChangeGeneric
+    //         (
+    //             target,
+    //             new EntityStateGeneric(entityId, "same"),
+    //             new EntityStateGeneric(entityId, "same")
+    //         ));
 
-        haContextMock.Verify(h => h.CallService("domain", "service", It.Is<ServiceTarget>(t => t.EntityIds!.Single() == entity.EntityId), data), Times.Once);
-    }
-
-    [Fact]
-    public void AsNumeric_Than_WithAttributesAs()
-    {
-        var entityId = "sensor.temperature";
-
-        var haContextMock = new HaContextMock();
-        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(
-            new EntityStateGeneric(entityId, "12.3", JsonSerializer.Deserialize<JsonElement>(@"{""setPoint"": 21.5, ""units"": ""Celcius""}"))
-        );
-
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
-
-        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.TypedAttributes<TestEntityAttributes>());
-        entity.State.Should().Be("12.3");
-
-        entity.WithStateAs(s => s);
-
-        // Act: AsNumeric
-        var numericEntity = entity.AsNumeric();
-
-        // Assert
-        numericEntity.State!.Value!.Should().Be(12.3d);
-        numericEntity.EntityState!.State!.Value!.Should().Be(12.3d);
-        numericEntity.StateAllChanges().Where(e => e.New?.State > 1.2);
-        // Act: WithNewAttributesAs
-        var withAttributes = numericEntity.WithAttributesAs<TestSensorAttributes>();
-
-        // Assert
-        withAttributes.State!.Value!.Should().Be(12.3d);
-        withAttributes.EntityState!.State!.Value!.Should().Be(12.3d);
-
-        withAttributes.Attributes!.units.Should().Be("Celcius");
-        withAttributes.Attributes!.setPoint.Should().Be(21.5);
-        withAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
-        withAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
-        withAttributes.StateAllChanges().Where(e => e.New?.State > 1.2 && e.Entity != null);
-
-    }
-
-    [Fact]
-    public void WithAttributesAs_Than_AsNumeric()
-    {
-        var entityId = "sensor.temperature";
-
-        var haContextMock = new HaContextMock();
-        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(
-            new EntityStateGeneric(entityId, "12.3", JsonSerializer.Deserialize<JsonElement>(@"{""setPoint"": 21.5, ""units"": ""Celcius""}"))
-        );
-
-        var entityFactory = new EntityGenericFactory(haContextMock.Object);
-        var entity = entityFactory.CreateIEntity(entityId, DefaultEntityStateMappers.Base);
-
-        // Act: WithAttributesAs
-        IEntity<string?, TestSensorAttributes> withAttributes = entity.WithAttributesAs<TestSensorAttributes>();
-        IEntity<double?, TestSensorAttributes> numericEntity = withAttributes.AsNumeric();
-
-        // Assert
-        withAttributes.State.Should().Be("12.3", because: "State  is still a string");
-
-        withAttributes.Attributes!.units.Should().Be("Celcius");
-        withAttributes.Attributes!.setPoint.Should().Be(21.5);
-        withAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
-        withAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
-
-        // Act: AsNumeric() 
-        var numericWithAttributes = withAttributes.AsNumeric();
-
-        numericWithAttributes.State!.Value!.Should().Be(12.3d);
-        numericWithAttributes.EntityState!.State!.Value!.Should().Be(12.3d);
-
-        numericWithAttributes.Attributes!.units.Should().Be("Celcius");
-        numericWithAttributes.Attributes!.setPoint.Should().Be(21.5);
-        numericWithAttributes.EntityState!.Attributes!.units.Should().Be("Celcius");
-        numericWithAttributes.EntityState!.Attributes!.setPoint.Should().Be(21.5);
-
-        haContextMock.StateAllChangeGenericSubject.OnNext(new StateChangeGeneric(entity, new EntityStateGeneric(entity.EntityId), new EntityStateGeneric(entity.EntityId)));
-        numericWithAttributes.StateAllChanges().Where(e => e.New?.State > 1.2 && e.Entity != null).Subscribe();
-
-    }
-
-    record TestSensorAttributes(double setPoint, string units);
-
-    [Fact]
-    public void NumericShouldShowStateChangesFromContext()
-    {
-        var haContextMock = new HaContextMock();
-
-        var entity = new Entity(haContextMock.Object, "domain.testEntity");
-        var target = new NumericEntity(entity);
-
-        haContextMock.Setup(m => m.GetState(entity.EntityId)).Returns(new EntityState() { State = "3.14" });
-
-        var stateAllChangeObserverMock = target.StateAllChanges().SubscribeMock();
-        var stateChangeObserverMock = target.StateChanges().SubscribeMock();
-
-        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
-            old: new EntityState { State = "1" },
-            @new: new EntityState { State = "1" }));
-
-        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
-            old: new EntityState { State = "1" },
-            @new: new EntityState { State = "2" }));
-
-        // Assert
-        stateChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(2.0))), Times.Once);
-        stateChangeObserverMock.VerifyNoOtherCalls();
-
-        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(2.0))), Times.Once);
-
-        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(1.0))), Times.Once);
-        stateAllChangeObserverMock.VerifyNoOtherCalls();
-    }
-
-    [Fact]
-    public void GenericNumericEntityShouldShowStateChangesFromContext()
-    {
-        // Arrange
-        var haContextMock = new HaContextMock();
-
-        var entity = new Entity(haContextMock.Object, "domain.testEntity");
-        var target = new NumericTestEntity(entity);
-
-        var stateChangeObserverMock = target.StateChanges().SubscribeMock();
-        var stateAllChangeObserverMock = target.StateAllChanges().SubscribeMock();
-
-        haContextMock.Setup(m => m.GetState(entity.EntityId)).Returns(new EntityState() { State = "3.14" });
-
-        // Act
-        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
-            old: new EntityState { State = "1" },
-            @new: new EntityState { State = "1" }));
-
-        haContextMock.StateAllChangeSubject.OnNext(new StateChange(entity,
-            old: new EntityState { State = "1" },
-            @new: new EntityState { State = "2" }));
-
-        // Assert
-        stateChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(2.0))), Times.Once);
-        stateChangeObserverMock.VerifyNoOtherCalls();
-
-        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(2.0))), Times.Once);
-
-        stateAllChangeObserverMock.Verify(o => o.OnNext(It.Is<NumericStateChange<NumericTestEntity, NumericEntityState<TestEntityAttributes>>>
-        (e => e.Entity.State.Equals(3.14) &&
-              e.Old!.State.Equals(1.0) &&
-              e.New!.State.Equals(1.0))), Times.Once);
-        stateAllChangeObserverMock.VerifyNoOtherCalls();
-    }
-
-    [Fact]
-    public void StatePropertyShouldBeCultureUnaware()
-    {
-        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("De-de");
-
-        var entityId = "sensor.temperature";
-
-        var haContextMock = new HaContextMock();
-        haContextMock.Setup(m => m.GetStateGeneric(entityId)).Returns(new EntityStateGeneric(entityId, "12.5"));
-
-        var entity = new EntityGenericFactory(haContextMock.Object).CreateIEntity(entityId, DefaultEntityStateMappers.Base);
-
-        var numericEntity = entity.AsNumeric();
-        numericEntity.State.Should().Be(12.5);
-        numericEntity.EntityState!.State.Should().Be(12.5);
-
-        var withAttributesAs = numericEntity.WithAttributesAs<TestEntityAttributes>();
-        withAttributesAs.State.Should().Be(12.5);
-        withAttributesAs.EntityState!.State.Should().Be(12.5);
-    }
+    //     stateChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Once);
+    //     stateAllChangeObserverMock.Verify(o => o.OnNext(It.IsAny<IStateChange>()), Times.Exactly(2));
+    // }
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMock.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMock.cs
@@ -8,9 +8,11 @@ internal class HaContextMock : Mock<IHaContext>
     public HaContextMock()
     {
         Setup(m => m.StateAllChanges()).Returns(StateAllChangeSubject);
+        Setup(m => m.StateAllChangesGeneric()).Returns(StateAllChangeGenericSubject);
         Setup(m => m.Events).Returns(EventsSubject);
     }
 
     public Subject<StateChange> StateAllChangeSubject { get; } = new();
+    public Subject<IStateChange> StateAllChangeGenericSubject { get; } = new();
     public Subject<Event> EventsSubject { get; } = new();
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMock.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMock.cs
@@ -8,11 +8,9 @@ internal class HaContextMock : Mock<IHaContext>
     public HaContextMock()
     {
         Setup(m => m.StateAllChanges()).Returns(StateAllChangeSubject);
-        Setup(m => m.StateAllChangesGeneric()).Returns(StateAllChangeGenericSubject);
         Setup(m => m.Events).Returns(EventsSubject);
     }
 
     public Subject<StateChange> StateAllChangeSubject { get; } = new();
-    public Subject<IStateChange> StateAllChangeGenericSubject { get; } = new();
     public Subject<Event> EventsSubject { get; } = new();
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMockGeneric.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/TestHelpers/HassClient/HaContextMockGeneric.cs
@@ -1,0 +1,17 @@
+// using System.Reactive.Subjects;
+// using NetDaemon.HassModel.Entities;
+// using NetDaemon.Client.HomeAssistant.Model;
+
+// namespace NetDaemon.HassModel.Tests.TestHelpers.HassClient;
+
+// internal class HaContextMockGeneric<TState, TAttributes> : Mock<IHaContext>
+// {
+//     public HaContextMockGeneric()
+//     {
+//         Setup(m => m.StateAllChangesGeneric(It.IsAny<Func<IHaContext, HassStateChangeEventData, IStateChange<TState, TAttributes>>> mapper)).Returns<Func<IHaContext, HassStateChangeEventData, IStateChange<TState, TAttributes>>>(mapper => mapper(HassStateChangedEventDataSubject));
+//         Setup(m => m.Events).Returns(EventsSubject);
+//     }
+
+//     public Subject<HassStateChangedEventData> HassStateChangedEventDataSubject { get; } = new();
+//     public Subject<Event> EventsSubject { get; } = new();
+// }

--- a/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
@@ -10,7 +10,11 @@ public static class DefaultEntityStateMappers
     private static Dictionary<string, object> AttributesAsObjectDictionary(JsonElement? a) =>
         a?.Deserialize<Dictionary<string, object>>() ?? new Dictionary<string, object>();
 
-    private static TAttributes? AttributesAsClass<TAttributes>(JsonElement? a) where TAttributes : class =>
+    /// <summary>
+    /// Parses the attributes JSON into the class TAttributes
+    /// </summary>
+    /// <typeparam name="TAttributes"></typeparam>
+    public static TAttributes? AttributesAsClass<TAttributes>(JsonElement? a) where TAttributes : class =>
         a?.Deserialize<TAttributes>() ?? default;
 
     /// <summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
@@ -1,5 +1,8 @@
 namespace NetDaemon.HassModel.Entities;
 
+/// <summary>
+/// A Collection of useful `EntityStateMapper` instances
+/// </summary>
 public static class DefaultEntityStateMappers
 {
     private static string? StateAsString(string? s) => s;
@@ -7,9 +10,48 @@ public static class DefaultEntityStateMappers
     private static Dictionary<string, object> AttributesAsObjectDictionary(JsonElement? a) =>
         a?.Deserialize<Dictionary<string, object>>() ?? new Dictionary<string, object>();
 
+    private static TAttributes? AttributesAsClass<TAttributes>(JsonElement? a) where TAttributes : class =>
+        a?.Deserialize<TAttributes>() ?? default;
+
+    /// <summary>
+    /// Matches the types of the original `Entity` class
+    /// </summary>
+    /// <returns></returns>
     public static IEntityStateMapper<string?, Dictionary<string, object>> Base =>
         new EntityStateMapper<string?, Dictionary<string, object>>(StateAsString, AttributesAsObjectDictionary);
 
+    /// <summary>
+    /// Matches the types of the Original `Entity&lt;TAttributes&gt;` class
+    /// </summary>
+    /// <typeparam name="TAttributes"></typeparam>
+    public static IEntityStateMapper<string?, TAttributes> TypedAttributes<TAttributes>() where TAttributes : class =>
+        new EntityStateMapper<string?, TAttributes>(StateAsString, AttributesAsClass<TAttributes>);
+
+    /// <summary>
+    /// Matches the types of the original NumericEntity class
+    /// </summary>
+    /// <returns></returns>
     public static IEntityStateMapper<double?, Dictionary<string, object>> NumericBase =>
         new EntityStateMapper<double?, Dictionary<string, object>>(FormatHelpers.ParseAsDouble, AttributesAsObjectDictionary);
+
+    /// <summary>
+    /// Matches the types of the Original NumericEntity&lt;TAttributes&gt; class
+    /// </summary>
+    /// <typeparam name="TAttributes"></typeparam>
+    public static IEntityStateMapper<double?, TAttributes> NumericTypedAttributes<TAttributes>() where TAttributes : class =>
+        new EntityStateMapper<double?, TAttributes>(FormatHelpers.ParseAsDouble, AttributesAsClass<TAttributes>);
+
+    /// <summary>
+    /// Parse the state as a DateTime
+    /// </summary>
+    /// <returns></returns>
+    public static IEntityStateMapper<DateTime?, Dictionary<string, object>> DateTimeBase =>
+        new EntityStateMapper<DateTime?, Dictionary<string, object>>(s => s is null ? null : DateTime.Parse(s), AttributesAsObjectDictionary);
+
+    /// <summary>
+    /// Parse the state as a DateTime and parse the attributes into a class
+    /// </summary>
+    /// <typeparam name="TAttributes"></typeparam>
+    public static IEntityStateMapper<DateTime?, TAttributes> DateTimeTypedAttributes<TAttributes>() where TAttributes : class =>
+        new EntityStateMapper<DateTime?, TAttributes>(s => s is null ? null : DateTime.Parse(s), AttributesAsClass<TAttributes>);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/DefaultEntityStateMapper.cs
@@ -1,0 +1,15 @@
+namespace NetDaemon.HassModel.Entities;
+
+public static class DefaultEntityStateMappers
+{
+    private static string? StateAsString(string? s) => s;
+
+    private static Dictionary<string, object> AttributesAsObjectDictionary(JsonElement? a) =>
+        a?.Deserialize<Dictionary<string, object>>() ?? new Dictionary<string, object>();
+
+    public static IEntityStateMapper<string?, Dictionary<string, object>> Base =>
+        new EntityStateMapper<string?, Dictionary<string, object>>(StateAsString, AttributesAsObjectDictionary);
+
+    public static IEntityStateMapper<double?, Dictionary<string, object>> NumericBase =>
+        new EntityStateMapper<double?, Dictionary<string, object>>(FormatHelpers.ParseAsDouble, AttributesAsObjectDictionary);
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
@@ -57,6 +57,7 @@ public static class EntityExtensions
     internal static IObservable<T> StateChangesOnly<T>(this IObservable<T> changes) where T : StateChange
         => changes.Where(c => c.New?.State != c.Old?.State);
 
-    internal static IObservable<T> StateChangesOnlyGeneric<T>(this IObservable<T> changes) where T : IStateChange
+    internal static IObservable<T> StateChangesOnlyGeneric<T>(this IObservable<T> changes)
+        where T : IStateChange
         => changes.Where(c => c.RawNew?.RawState != c.RawOld?.RawState);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
@@ -57,7 +57,7 @@ public static class EntityExtensions
     internal static IObservable<T> StateChangesOnly<T>(this IObservable<T> changes) where T : StateChange
         => changes.Where(c => c.New?.State != c.Old?.State);
 
-    internal static IObservable<T> StateChangesOnlyGeneric<T>(this IObservable<T> changes)
-        where T : IStateChange
-        => changes.Where(c => c.RawNew?.RawState != c.RawOld?.RawState);
+    // internal static IObservable<T> StateChangesOnlyGeneric<T>(this IObservable<T> changes)
+    //     where T : IStateChange
+    //     => changes.Where(c => c.RawNew?.RawState != c.RawOld?.RawState);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityExtensions.cs
@@ -56,4 +56,7 @@ public static class EntityExtensions
 
     internal static IObservable<T> StateChangesOnly<T>(this IObservable<T> changes) where T : StateChange
         => changes.Where(c => c.New?.State != c.Old?.State);
+
+    internal static IObservable<T> StateChangesOnlyGeneric<T>(this IObservable<T> changes) where T : IStateChange
+        => changes.Where(c => c.RawNew?.RawState != c.RawOld?.RawState);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
@@ -1,27 +1,35 @@
 namespace NetDaemon.HassModel.Entities;
 
-public record EntityGeneric : IEntity
+/// <inheritdoc/>
+public sealed record EntityGeneric : IEntity
 {
+    /// <inheritdoc/>
     public IHaContext HaContext { get; }
 
+    /// <inheritdoc/>
     public string EntityId { get; }
 
-    public EntityGeneric(IHaContext haContext, string entityId)
+    internal EntityGeneric(IHaContext haContext, string entityId)
     {
         HaContext = haContext;
         EntityId = entityId;
     }
 
+    /// <inheritdoc/>
     public IEntityState? RawEntityState => HaContext.GetStateGeneric(EntityId);
 
+    /// <inheritdoc/>
     public string? RawState => RawEntityState?.RawState;
 
+    /// <inheritdoc/>
     public IObservable<IStateChange> RawStateAllChanges() =>
         HaContext.StateAllChangesGeneric().Where(e => e.Entity.EntityId == EntityId);
 
+    /// <inheritdoc/>
     public IObservable<IStateChange> RawStateChanges() =>
         RawStateAllChanges().StateChangesOnlyGeneric();
 
+    /// <inheritdoc/>
     public void CallService(string service, object? data = null)
     {
         ArgumentNullException.ThrowIfNull(service, nameof(service));
@@ -34,49 +42,57 @@ public record EntityGeneric : IEntity
     }
 }
 
-public record EntityGeneric<TState, TAttributes> : IEntity<TState, TAttributes>
+/// <inheritdoc/>
+public sealed record EntityGeneric<TState, TAttributes> : IEntity<TState, TAttributes>
     where TAttributes : class
 {
     private readonly IEntity _entity;
     private readonly IEntityStateMapper<TState, TAttributes> _mapper;
 
-    public EntityGeneric(IEntity entity, Func<string?, TState> stateParser, Func<JsonElement?, TAttributes> attributesParser)
-    {
-        _entity = entity;
-        _mapper = new EntityStateMapper<TState, TAttributes>(stateParser, attributesParser);
-    }
-
-    public EntityGeneric(IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
+    internal EntityGeneric(IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
     {
         _entity = entity;
         _mapper = mapper;
     }
 
+    /// <inheritdoc/>
     public IHaContext HaContext => _entity.HaContext;
 
+    /// <inheritdoc/>
     public string EntityId => _entity.EntityId;
 
+    /// <inheritdoc/>
     public IEntityState? RawEntityState => _entity.RawEntityState;
 
+    /// <inheritdoc/>
     public IEntityState<TState, TAttributes>? EntityState =>
         _entity.RawEntityState is null
             ? null
             : _mapper.Map(_entity.RawEntityState);
+
+    /// <inheritdoc/>
     public TState State => EntityState is null ? _mapper.ParseState(null) : EntityState.State;
 
+    /// <inheritdoc/>
     public string? RawState => _entity.RawState;
 
-    public TAttributes Attributes => EntityState is null ? _mapper.ParseAttributes(null) : EntityState.Attributes;
+    /// <inheritdoc/>
+    public TAttributes? Attributes => EntityState is null ? _mapper.ParseAttributes(null) : EntityState.Attributes;
 
+    /// <inheritdoc/>
     public void CallService(string service, object? data = null) => _entity.CallService(service, data);
 
+    /// <inheritdoc/>
     public IObservable<IStateChange> RawStateAllChanges() => _entity.RawStateAllChanges();
 
+    /// <inheritdoc/>
     public IObservable<IStateChange> RawStateChanges() => _entity.RawStateChanges();
 
+    /// <inheritdoc/>
     public IObservable<IStateChange<TState, TAttributes>> StateAllChanges() =>
         _entity.RawStateAllChanges().Select(_mapper.Map);
 
+    /// <inheritdoc/>
     public IObservable<IStateChange<TState, TAttributes>> StateChanges() =>
         StateAllChanges().StateChangesOnlyGeneric();
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
@@ -1,0 +1,82 @@
+namespace NetDaemon.HassModel.Entities;
+
+public record EntityGeneric : IEntity
+{
+    public IHaContext HaContext { get; }
+
+    public string EntityId { get; }
+
+    public EntityGeneric(IHaContext haContext, string entityId)
+    {
+        HaContext = haContext;
+        EntityId = entityId;
+    }
+
+    public IEntityState? RawEntityState => HaContext.GetStateGeneric(EntityId);
+
+    public string? RawState => RawEntityState?.RawState;
+
+    public IObservable<IStateChange> RawStateAllChanges() =>
+        HaContext.StateAllChangesGeneric().Where(e => e.Entity.EntityId == EntityId);
+
+    public IObservable<IStateChange> RawStateChanges() =>
+        RawStateAllChanges().StateChangesOnlyGeneric();
+
+    public void CallService(string service, object? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(service, nameof(service));
+
+        var (serviceDomain, serviceName) = service.SplitAtDot();
+
+        serviceDomain ??= EntityId.SplitAtDot().Left ?? throw new InvalidOperationException("EntityId must be formatted 'domain.name'");
+
+        HaContext.CallService(serviceDomain, serviceName, ServiceTarget.FromEntity(EntityId), data);
+    }
+}
+
+public record EntityGeneric<TState, TAttributes> : IEntity<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly IEntity _entity;
+    private readonly IEntityStateMapper<TState, TAttributes> _mapper;
+
+    public EntityGeneric(IEntity entity, Func<string?, TState> stateParser, Func<JsonElement?, TAttributes> attributesParser)
+    {
+        _entity = entity;
+        _mapper = new EntityStateMapper<TState, TAttributes>(stateParser, attributesParser);
+    }
+
+    public EntityGeneric(IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
+    {
+        _entity = entity;
+        _mapper = mapper;
+    }
+
+    public IHaContext HaContext => _entity.HaContext;
+
+    public string EntityId => _entity.EntityId;
+
+    public IEntityState? RawEntityState => _entity.RawEntityState;
+
+    public IEntityState<TState, TAttributes>? EntityState =>
+        _entity.RawEntityState is null
+            ? null
+            : _mapper.Map(_entity.RawEntityState);
+    public TState State => EntityState is null ? _mapper.ParseState(null) : EntityState.State;
+
+    public string? RawState => _entity.RawState;
+
+    public TAttributes Attributes => EntityState is null ? _mapper.ParseAttributes(null) : EntityState.Attributes;
+
+    public void CallService(string service, object? data = null) => _entity.CallService(service, data);
+
+    public IObservable<IStateChange> RawStateAllChanges() => _entity.RawStateAllChanges();
+
+    public IObservable<IStateChange> RawStateChanges() => _entity.RawStateChanges();
+
+    public IObservable<IStateChange<TState, TAttributes>> StateAllChanges() =>
+        _entity.RawStateAllChanges().Select(_mapper.Map);
+
+    public IObservable<IStateChange<TState, TAttributes>> StateChanges() =>
+        StateAllChanges().StateChangesOnlyGeneric();
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGeneric.cs
@@ -14,7 +14,7 @@ public sealed record EntityGeneric<TState, TAttributes> : IEntity<TState, TAttri
     public IEntityStateMapper<TState, TAttributes> EntityStateMapper { get; }
 
     /// <inheritdoc/>
-    public IEntityState? RawEntityState => HaContext.GetStateGeneric(EntityId);
+    public IEntityState? RawEntityState => HaContext.GetState(EntityId, EntityStateMapper.MapHassState);
 
     /// <inheritdoc/>
     public string? RawState => RawEntityState?.RawState;
@@ -39,16 +39,8 @@ public sealed record EntityGeneric<TState, TAttributes> : IEntity<TState, TAttri
     public TAttributes? Attributes => EntityState is null ? EntityStateMapper.ParseAttributes(null) : EntityState.Attributes;
 
     /// <inheritdoc/>
-    public IObservable<IStateChange> RawStateAllChanges() =>
-        HaContext.StateAllChangesGeneric().Where(e => e.Entity.EntityId == EntityId);
-
-    /// <inheritdoc/>
-    public IObservable<IStateChange> RawStateChanges() =>
-        RawStateAllChanges().StateChangesOnlyGeneric();
-
-    /// <inheritdoc/>
     public IObservable<IStateChange<TState, TAttributes>> StateAllChanges() =>
-        RawStateAllChanges().Select(EntityStateMapper.Map);
+        HaContext.StateAllChangesGeneric(EntityStateMapper.MapHassStateChange).Where(e => e.Entity.EntityId == EntityId);
 
     /// <inheritdoc/>
     public IObservable<IStateChange<TState, TAttributes>> StateChanges() =>

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
@@ -11,10 +11,13 @@ public static class EntityGenericExtensions
     /// </summary>
     /// <param name="entity">The source entity</param>
     /// <param name="mapper">The type mapper from raw values to the target types</param>
+    /// <typeparam name="TStateOld"></typeparam>
+    /// <typeparam name="TAttributesOld"></typeparam>
     /// <typeparam name="TState"></typeparam>
     /// <typeparam name="TAttributes"></typeparam>
     /// <returns></returns>
-    public static IEntity<TState, TAttributes> MappedBy<TState, TAttributes>(this IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
+    public static IEntity<TState, TAttributes> MappedBy<TStateOld, TAttributesOld, TState, TAttributes>(this IEntity<TStateOld, TAttributesOld> entity, IEntityStateMapper<TState, TAttributes> mapper)
+        where TAttributesOld : class
         where TAttributes : class
         => mapper.Map(entity);
 
@@ -27,7 +30,7 @@ public static class EntityGenericExtensions
     /// <typeparam name="TState"></typeparam>
     /// <typeparam name="TAttributes"></typeparam>
     /// <returns></returns>
-    public static IEntity<TStateNew, TAttributes> WithStateAsExt<TStateNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<string?, TStateNew> newStateParser)
+    public static IEntity<TStateNew, TAttributes> WithStateAs<TStateNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<string?, TStateNew> newStateParser)
         where TAttributes : class
         => entity.EntityStateMapper.WithStateAs(newStateParser).Map(entity);
 
@@ -40,30 +43,18 @@ public static class EntityGenericExtensions
     /// <typeparam name="TState"></typeparam>
     /// <typeparam name="TAttributes"></typeparam>
     /// <returns></returns>
-    public static IEntity<TState, TAttributesNew> WithAttributesAsExt<TAttributesNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<JsonElement?, TAttributesNew> newAttributesParser)
+    public static IEntity<TState, TAttributesNew> WithAttributesAs<TAttributesNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<JsonElement?, TAttributesNew> newAttributesParser)
         where TAttributesNew : class
         where TAttributes : class
         => entity.EntityStateMapper.WithAttributesAs(newAttributesParser).Map(entity);
-
-    /// <summary>
-    /// Get a new IEntity with a new attributes class mapping using the default parser
-    /// </summary>
-    /// <param name="entity"></param>
-    /// <typeparam name="TAttributesNew"></typeparam>
-    /// <typeparam name="TState"></typeparam>
-    /// <typeparam name="TAttributes"></typeparam>
-    /// <returns></returns>
-    public static IEntity<TState, TAttributesNew> WithAttributesAsExt<TAttributesNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity)
-        where TAttributesNew : class
-        where TAttributes : class
-        => entity.EntityStateMapper.WithAttributesAs<TAttributesNew>().Map(entity);
     
     /// <summary>
     /// Get a Numeric IEntity from a given IEntity
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    public static IEntity<double?, Dictionary<string, object>> ToNumeric(this IEntity entity)
+    public static IEntity<double?, Dictionary<string, object>> ToNumeric<TState, TAttributes>(this IEntity<TState, TAttributes> entity)
+        where TAttributes : class
         => DefaultEntityStateMappers.NumericBase.Map(entity);
     
     /// <summary>
@@ -71,28 +62,9 @@ public static class EntityGenericExtensions
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    public static IEntity<DateTime?, Dictionary<string, object>> ToDateTime(this IEntity entity)
+    public static IEntity<DateTime?, Dictionary<string, object>> ToDateTime<TState, TAttributes>(this IEntity<TState, TAttributes> entity)
+        where TAttributes : class
         => DefaultEntityStateMappers.DateTimeBase.Map(entity);
-    
-    /// <summary>
-    /// Get a Numeric IEntity from a given IEntity
-    /// </summary>
-    /// <param name="entity"></param>
-    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
-    /// <returns></returns>
-    public static IEntity<double?, TAttributes> AsNumeric<TAttributes>(this IEntity entity)
-        where TAttributes : class
-        => DefaultEntityStateMappers.NumericTypedAttributes<TAttributes>().Map(entity);
-    
-    /// <summary>
-    /// Get a DateTime IEntity from a given IEntity 
-    /// </summary>
-    /// <param name="entity"></param>
-    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
-    /// <returns></returns>
-    public static IEntity<DateTime?, TAttributes> AsDateTime<TAttributes>(this IEntity entity)
-        where TAttributes : class
-        => DefaultEntityStateMappers.DateTimeTypedAttributes<TAttributes>().Map(entity);
     
     /// <summary>
     /// Get a Numeric IEntity from a given IEntity

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
@@ -1,0 +1,78 @@
+namespace NetDaemon.HassModel.Entities;
+
+/// <summary>
+/// Extension methods for IEntities
+/// </summary>
+public static class EntityGenericExtensions
+{
+    /// <summary>
+    /// Get a strongly typed IEntity&lt;TState, TAttributes&gt; from any IEntity
+    /// This will work if and only if the underlying JSON is compatible with your types.
+    /// </summary>
+    /// <param name="entity">The source entity</param>
+    /// <param name="mapper">The type mapper from raw values to the target types</param>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TAttributes"></typeparam>
+    /// <returns></returns>
+    public static IEntity<TState, TAttributes> AsEntityStateType<TState, TAttributes>(this IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
+        where TAttributes : class
+        => mapper.Map(entity);
+    
+    /// <summary>
+    /// Get a Numeric IEntity from a given IEntity
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    public static IEntity<double?, Dictionary<string, object>> ToNumeric(this IEntity entity)
+        => DefaultEntityStateMappers.NumericBase.Map(entity);
+    
+    /// <summary>
+    /// Get a DateTime IEntity from a given IEntity 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    public static IEntity<DateTime?, Dictionary<string, object>> ToDateTime(this IEntity entity)
+        => DefaultEntityStateMappers.DateTimeBase.Map(entity);
+    
+    /// <summary>
+    /// Get a Numeric IEntity from a given IEntity
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
+    /// <returns></returns>
+    public static IEntity<double?, TAttributes> AsNumeric<TAttributes>(this IEntity entity)
+        where TAttributes : class
+        => DefaultEntityStateMappers.NumericTypedAttributes<TAttributes>().Map(entity);
+    
+    /// <summary>
+    /// Get a DateTime IEntity from a given IEntity 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
+    /// <returns></returns>
+    public static IEntity<DateTime?, TAttributes> AsDateTime<TAttributes>(this IEntity entity)
+        where TAttributes : class
+        => DefaultEntityStateMappers.DateTimeTypedAttributes<TAttributes>().Map(entity);
+    
+    /// <summary>
+    /// Get a Numeric IEntity from a given IEntity
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TState">Is ignored</typeparam>
+    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
+    /// <returns></returns>
+    public static IEntity<double?, TAttributes> AsNumeric<TState, TAttributes>(this IEntity<TState, TAttributes> entity)
+        where TAttributes : class
+        => DefaultEntityStateMappers.NumericTypedAttributes<TAttributes>().Map(entity);
+    
+    /// <summary>
+    /// Get a DateTime IEntity from a given IEntity 
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TState">Is ignored</typeparam>
+    /// <typeparam name="TAttributes">Is kept unchanged</typeparam>
+    /// <returns></returns>
+    public static IEntity<DateTime?, TAttributes> AsDateTime<TState, TAttributes>(this IEntity<TState, TAttributes> entity)
+        where TAttributes : class
+        => DefaultEntityStateMappers.DateTimeTypedAttributes<TAttributes>().Map(entity);
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
@@ -17,6 +17,46 @@ public static class EntityGenericExtensions
     public static IEntity<TState, TAttributes> AsEntityStateType<TState, TAttributes>(this IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
         where TAttributes : class
         => mapper.Map(entity);
+
+    /// <summary>
+    /// Get a new IEntity with new state type mapping
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="newStateParser"></param>
+    /// <typeparam name="TStateNew"></typeparam>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TAttributes"></typeparam>
+    /// <returns></returns>
+    public static IEntity<TStateNew, TAttributes> WithStateAsExt<TStateNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<string?, TStateNew> newStateParser)
+        where TAttributes : class
+        => entity.EntityStateMapper.WithStateAs(newStateParser).Map(entity);
+
+    /// <summary>
+    /// Get a new IEntity with a new attributes class mapping
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="newAttributesParser"></param>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TAttributes"></typeparam>
+    /// <returns></returns>
+    public static IEntity<TState, TAttributesNew> WithAttributesAsExt<TAttributesNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity, Func<JsonElement?, TAttributesNew> newAttributesParser)
+        where TAttributesNew : class
+        where TAttributes : class
+        => entity.EntityStateMapper.WithAttributesAs(newAttributesParser).Map(entity);
+
+    /// <summary>
+    /// Get a new IEntity with a new attributes class mapping using the default parser
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TAttributes"></typeparam>
+    /// <returns></returns>
+    public static IEntity<TState, TAttributesNew> WithAttributesAsExt<TAttributesNew, TState, TAttributes>(this IEntity<TState, TAttributes> entity)
+        where TAttributesNew : class
+        where TAttributes : class
+        => entity.EntityStateMapper.WithAttributesAs<TAttributesNew>().Map(entity);
     
     /// <summary>
     /// Get a Numeric IEntity from a given IEntity

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericExtensions.cs
@@ -14,7 +14,7 @@ public static class EntityGenericExtensions
     /// <typeparam name="TState"></typeparam>
     /// <typeparam name="TAttributes"></typeparam>
     /// <returns></returns>
-    public static IEntity<TState, TAttributes> AsEntityStateType<TState, TAttributes>(this IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
+    public static IEntity<TState, TAttributes> MappedBy<TState, TAttributes>(this IEntity entity, IEntityStateMapper<TState, TAttributes> mapper)
         where TAttributes : class
         => mapper.Map(entity);
 

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericFactory.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericFactory.cs
@@ -13,6 +13,6 @@ public sealed class EntityGenericFactory : IEntityFactory
 
     /// <inheritdoc/>
     public IEntity<TState, TAttributes> CreateIEntity<TState, TAttributes>(string entityId, IEntityStateMapper<TState, TAttributes> mapper)
-        where TAttributes : class =>
-        new EntityGeneric<TState, TAttributes>(new EntityGeneric(_haContext, entityId), mapper);
+        where TAttributes : class
+        => mapper.Entity(_haContext, entityId);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericFactory.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityGenericFactory.cs
@@ -1,0 +1,18 @@
+namespace NetDaemon.HassModel.Entities;
+
+/// <inheritdoc/>
+public sealed class EntityGenericFactory : IEntityFactory
+{
+    private readonly IHaContext _haContext;
+
+    /// <summary>
+    /// Create an IEntityFactory that produces IEntity instances for the provided Home Assistant Context
+    /// </summary>
+    /// <param name="haContext">Home Assistant Context used with produced entities</param>
+    public EntityGenericFactory(IHaContext haContext) => _haContext = haContext;
+
+    /// <inheritdoc/>
+    public IEntity<TState, TAttributes> CreateIEntity<TState, TAttributes>(string entityId, IEntityStateMapper<TState, TAttributes> mapper)
+        where TAttributes : class =>
+        new EntityGeneric<TState, TAttributes>(new EntityGeneric(_haContext, entityId), mapper);
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
@@ -38,18 +38,6 @@ public sealed record EntityStateGeneric<TState, TAttributes> : IEntityState<TSta
         _attributesLazy = new (() => mapper.ParseAttributes(AttributesJson));
     }
 
-    internal EntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
-    {
-        EntityId = entityState.EntityId;
-        RawState = entityState.RawState;
-        AttributesJson = entityState.AttributesJson;
-        LastChanged = entityState.LastChanged;
-        LastUpdated = entityState.LastUpdated;
-        Context = entityState.Context;
-        _parseState = mapper.ParseState;
-        _attributesLazy = new (() => mapper.ParseAttributes(AttributesJson));
-    }
-
     /// <inheritdoc/>
     public TState State => _parseState(RawState);
 
@@ -90,18 +78,6 @@ public sealed record CachedEntityStateGeneric<TState, TAttributes> : IEntityStat
     internal CachedEntityStateGeneric(string entityId, IEntityStateMapper<TState, TAttributes> mapper)
     {
         EntityId = entityId;
-        _stateLazy = new (() => mapper.ParseState(RawState));
-        _attributesLazy = new (() => mapper.ParseAttributes(AttributesJson));
-    }
-
-    internal CachedEntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
-    {
-        EntityId = entityState.EntityId;
-        RawState = entityState.RawState;
-        AttributesJson = entityState.AttributesJson;
-        LastChanged = entityState.LastChanged;
-        LastUpdated = entityState.LastUpdated;
-        Context = entityState.Context;
         _stateLazy = new (() => mapper.ParseState(RawState));
         _attributesLazy = new (() => mapper.ParseAttributes(AttributesJson));
     }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
@@ -1,28 +1,23 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <inheritdoc/>
-public sealed record EntityStateGeneric : IEntityState
-{
-    /// <inheritdoc/>
-    public required string EntityId { get; init; }
+public sealed record EntityStateGeneric
+(
+    string EntityId,
+    string? RawState = null,
+    JsonElement? AttributesJson = null,
+    DateTime? LastChanged = null,
+    DateTime? LastUpdated = null,
+    Context? Context = null
+) : IEntityState;
 
-    /// <inheritdoc/>
-    public string? RawState { get; init; }
-
-    /// <inheritdoc/>
-    public JsonElement? AttributesJson { get; init; }
-
-    /// <inheritdoc/>
-    public DateTime? LastChanged { get; init; }
-
-    /// <inheritdoc/>
-    public DateTime? LastUpdated { get; init; }
-
-    /// <inheritdoc/>
-    public Context? Context { get; init; }
-}
-
-/// <inheritdoc/>
+/// <summary>
+/// Detailed state information where a strongly typed value is parsed each time it's accessed.
+/// This is the default behavior and ideal when the type is easily (or even trivially parsed if
+/// it's a string or wrapper of a string).
+/// </summary>
+/// <typeparam name="TState"></typeparam>
+/// <typeparam name="TAttributes"></typeparam>
 public sealed record EntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
     where TAttributes : class
 {
@@ -39,6 +34,51 @@ public sealed record EntityStateGeneric<TState, TAttributes> : IEntityState<TSta
 
     /// <inheritdoc/>
     public TState State => _mapper.ParseState(_entityState.RawState);
+
+    /// <inheritdoc/>
+    public TAttributes? Attributes => _attributesLazy.Value;
+
+    /// <inheritdoc/>
+    public string EntityId => _entityState.EntityId;
+
+    /// <inheritdoc/>
+    public string? RawState => _entityState.RawState;
+
+    /// <inheritdoc/>
+    public JsonElement? AttributesJson => _entityState.AttributesJson;
+
+    /// <inheritdoc/>
+    public DateTime? LastChanged => _entityState.LastChanged;
+
+    /// <inheritdoc/>
+    public DateTime? LastUpdated => _entityState.LastUpdated;
+
+    /// <inheritdoc/>
+    public Context? Context => _entityState.Context;
+}
+
+/// <summary>
+/// Detailed state information stored as a cached strongly typed value.
+/// The parsed value is cached.
+/// </summary>
+/// <typeparam name="TState"></typeparam>
+/// <typeparam name="TAttributes"></typeparam>
+public sealed record CachedEntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly IEntityState _entityState;
+    private readonly Lazy<TState> _stateLazy;
+    private readonly Lazy<TAttributes?> _attributesLazy;
+
+    internal CachedEntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
+    {
+        _entityState = entityState;
+        _stateLazy = new (() => mapper.ParseState(_entityState.RawState));
+        _attributesLazy = new (() => mapper.ParseAttributes(_entityState.AttributesJson));
+    }
+
+    /// <inheritdoc/>
+    public TState State => _stateLazy.Value;
 
     /// <inheritdoc/>
     public TAttributes? Attributes => _attributesLazy.Value;

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
@@ -1,0 +1,37 @@
+namespace NetDaemon.HassModel.Entities;
+
+public class EntityStateGeneric : IEntityState
+{
+    public required string EntityId { get; init; }
+    public string? RawState { get; init; }
+    public JsonElement? AttributesJson { get; init; }
+    public DateTime? LastChanged { get; init; }
+    public DateTime? LastUpdated { get; init; }
+    public Context? Context { get; init; }
+}
+
+public class EntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly IEntityState _entityState;
+    private readonly Lazy<TAttributes> _attributesLazy;
+    private readonly IEntityStateMapper<TState, TAttributes> _mapper;
+
+    public EntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
+    {
+        _entityState = entityState;
+        _mapper = mapper;
+        _attributesLazy = new (() => _mapper.ParseAttributes(_entityState.AttributesJson));
+    }
+
+    public TState State => _mapper.ParseState(_entityState.RawState);
+
+    public TAttributes Attributes => _attributesLazy.Value;
+
+    public string EntityId => _entityState.EntityId;
+    public string? RawState => _entityState.RawState;
+    public JsonElement? AttributesJson => _entityState.AttributesJson;
+    public DateTime? LastChanged => _entityState.LastChanged;
+    public DateTime? LastUpdated => _entityState.LastUpdated;
+    public Context? Context => _entityState.Context;
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
@@ -1,7 +1,7 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <inheritdoc/>
-public class EntityStateGeneric : IEntityState
+public sealed record EntityStateGeneric : IEntityState
 {
     /// <inheritdoc/>
     public required string EntityId { get; init; }
@@ -23,7 +23,7 @@ public class EntityStateGeneric : IEntityState
 }
 
 /// <inheritdoc/>
-public class EntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
+public sealed record EntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
     where TAttributes : class
 {
     private readonly IEntityState _entityState;

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateGeneric.cs
@@ -1,37 +1,63 @@
 namespace NetDaemon.HassModel.Entities;
 
+/// <inheritdoc/>
 public class EntityStateGeneric : IEntityState
 {
+    /// <inheritdoc/>
     public required string EntityId { get; init; }
+
+    /// <inheritdoc/>
     public string? RawState { get; init; }
+
+    /// <inheritdoc/>
     public JsonElement? AttributesJson { get; init; }
+
+    /// <inheritdoc/>
     public DateTime? LastChanged { get; init; }
+
+    /// <inheritdoc/>
     public DateTime? LastUpdated { get; init; }
+
+    /// <inheritdoc/>
     public Context? Context { get; init; }
 }
 
+/// <inheritdoc/>
 public class EntityStateGeneric<TState, TAttributes> : IEntityState<TState, TAttributes>
     where TAttributes : class
 {
     private readonly IEntityState _entityState;
-    private readonly Lazy<TAttributes> _attributesLazy;
+    private readonly Lazy<TAttributes?> _attributesLazy;
     private readonly IEntityStateMapper<TState, TAttributes> _mapper;
 
-    public EntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
+    internal EntityStateGeneric(IEntityState entityState, IEntityStateMapper<TState, TAttributes> mapper)
     {
         _entityState = entityState;
         _mapper = mapper;
         _attributesLazy = new (() => _mapper.ParseAttributes(_entityState.AttributesJson));
     }
 
+    /// <inheritdoc/>
     public TState State => _mapper.ParseState(_entityState.RawState);
 
-    public TAttributes Attributes => _attributesLazy.Value;
+    /// <inheritdoc/>
+    public TAttributes? Attributes => _attributesLazy.Value;
 
+    /// <inheritdoc/>
     public string EntityId => _entityState.EntityId;
+
+    /// <inheritdoc/>
     public string? RawState => _entityState.RawState;
+
+    /// <inheritdoc/>
     public JsonElement? AttributesJson => _entityState.AttributesJson;
+
+    /// <inheritdoc/>
     public DateTime? LastChanged => _entityState.LastChanged;
+
+    /// <inheritdoc/>
     public DateTime? LastUpdated => _entityState.LastUpdated;
+
+    /// <inheritdoc/>
     public Context? Context => _entityState.Context;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -1,25 +1,30 @@
 namespace NetDaemon.HassModel.Entities;
 
+/// <inheritdoc/>
 public class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<TState, TAttributes>
     where TAttributes : class
 {
     private readonly Func<string?, TState> _stateParser;
-    private readonly Func<JsonElement?, TAttributes> _attributesParser;
+    private readonly Func<JsonElement?, TAttributes?> _attributesParser;
 
-    public EntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes> attributesParser)
+    internal EntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes?> attributesParser)
     {
         _stateParser = stateParser;
         _attributesParser = attributesParser;
     }
 
+    /// <inheritdoc/>
     public TState ParseState(string? rawState) => _stateParser(rawState);
 
-    public TAttributes ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
+    /// <inheritdoc/>
+    public TAttributes? ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
 
+    /// <inheritdoc/>
     public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
 
+    /// <inheritdoc/>
     public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity, this);
 
-
+    /// <inheritdoc/>
     public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -1,0 +1,25 @@
+namespace NetDaemon.HassModel.Entities;
+
+public class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly Func<string?, TState> _stateParser;
+    private readonly Func<JsonElement?, TAttributes> _attributesParser;
+
+    public EntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes> attributesParser)
+    {
+        _stateParser = stateParser;
+        _attributesParser = attributesParser;
+    }
+
+    public TState ParseState(string? rawState) => _stateParser(rawState);
+
+    public TAttributes ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
+
+    public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
+
+    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity, this);
+
+
+    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -28,10 +28,13 @@ public sealed class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<
     public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
 
     /// <inheritdoc/>
-    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity, this);
+    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 
     /// <inheritdoc/>
-    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
+
+    /// <inheritdoc/>
+    public IEntity<TState, TAttributes> Entity(IHaContext haContext, string entityId) => new EntityGeneric<TState, TAttributes>(haContext, entityId, this);
 
     /// <inheritdoc/>
     public IEntityStateMapper<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser)
@@ -77,10 +80,13 @@ public sealed class CachedEntityStateMapper<TState, TAttributes> : IEntityStateM
     public IEntityState<TState, TAttributes> Map(IEntityState state) => new CachedEntityStateGeneric<TState, TAttributes>(state, this);
 
     /// <inheritdoc/>
-    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity, this);
+    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 
     /// <inheritdoc/>
-    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
+
+    /// <inheritdoc/>
+    public IEntity<TState, TAttributes> Entity(IHaContext haContext, string entityId) => new EntityGeneric<TState, TAttributes>(haContext, entityId, this);
 
     /// <inheritdoc/>
     public IEntityStateMapper<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser)

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -55,14 +55,13 @@ public sealed class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<
             MapHassState(hassStateChange.NewState)
         );
 
-    /// <inheritdoc/>
-    public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
-
     // /// <inheritdoc/>
     // public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 
     /// <inheritdoc/>
-    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
+    public IEntity<TState, TAttributes> Map<TStateOld, TAttributesOld>(IEntity<TStateOld, TAttributesOld> entity)
+        where TAttributesOld : class
+        => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
 
     /// <inheritdoc/>
     public IEntity<TState, TAttributes> Entity(IHaContext haContext, string entityId) => new EntityGeneric<TState, TAttributes>(haContext, entityId, this);
@@ -139,13 +138,9 @@ public sealed class CachedEntityStateMapper<TState, TAttributes> : IEntityStateM
         );
 
     /// <inheritdoc/>
-    public IEntityState<TState, TAttributes> Map(IEntityState state) => new CachedEntityStateGeneric<TState, TAttributes>(state, this);
-
-    // /// <inheritdoc/>
-    // public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
-
-    /// <inheritdoc/>
-    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
+    public IEntity<TState, TAttributes> Map<TStateOld, TAttributesOld>(IEntity<TStateOld, TAttributesOld> entity)
+        where TAttributesOld : class
+        => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
 
     /// <inheritdoc/>
     public IEntity<TState, TAttributes> Entity(IHaContext haContext, string entityId) => new EntityGeneric<TState, TAttributes>(haContext, entityId, this);

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -25,10 +25,41 @@ public sealed class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<
     public TAttributes? ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
 
     /// <inheritdoc/>
-    public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
+    public IEntityState<TState, TAttributes>? MapHassState(HassState? hassState)
+    {
+        if (hassState == null) return null;
+
+        return new EntityStateGeneric<TState, TAttributes>(hassState.EntityId, this)
+        {
+            RawState = hassState.State,
+            AttributesJson = hassState.AttributesJson,
+            LastChanged = hassState.LastChanged,
+            LastUpdated = hassState.LastUpdated,
+            Context = hassState.Context == null
+                ? null
+                : new Context
+                {
+                    Id = hassState.Context.Id,
+                    UserId = hassState.Context.UserId,
+                    ParentId = hassState.Context.UserId
+                }
+        };
+    }
+    
+    /// <inheritdoc/>
+    public IStateChange<TState, TAttributes> MapHassStateChange(IHaContext haContext, HassStateChangedEventData hassStateChange)
+        => new StateChangeGeneric<TState, TAttributes>
+        (
+            Entity(haContext, hassStateChange.EntityId),
+            MapHassState(hassStateChange.OldState),
+            MapHassState(hassStateChange.NewState)
+        );
 
     /// <inheritdoc/>
-    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+    public IEntityState<TState, TAttributes> Map(IEntityState state) => new EntityStateGeneric<TState, TAttributes>(state, this);
+
+    // /// <inheritdoc/>
+    // public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 
     /// <inheritdoc/>
     public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);
@@ -77,10 +108,41 @@ public sealed class CachedEntityStateMapper<TState, TAttributes> : IEntityStateM
     public TAttributes? ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
 
     /// <inheritdoc/>
-    public IEntityState<TState, TAttributes> Map(IEntityState state) => new CachedEntityStateGeneric<TState, TAttributes>(state, this);
+    public IEntityState<TState, TAttributes>? MapHassState(HassState? hassState)
+    {
+        if (hassState == null) return null;
+
+        return new CachedEntityStateGeneric<TState, TAttributes>(hassState.EntityId, this)
+        {
+            RawState = hassState.State,
+            AttributesJson = hassState.AttributesJson,
+            LastChanged = hassState.LastChanged,
+            LastUpdated = hassState.LastUpdated,
+            Context = hassState.Context == null
+                ? null
+                : new Context
+                {
+                    Id = hassState.Context.Id,
+                    UserId = hassState.Context.UserId,
+                    ParentId = hassState.Context.UserId
+                }
+        };
+    }
+    
+    /// <inheritdoc/>
+    public IStateChange<TState, TAttributes> MapHassStateChange(IHaContext haContext, HassStateChangedEventData hassStateChange)
+        => new StateChangeGeneric<TState, TAttributes>
+        (
+            Entity(haContext, hassStateChange.EntityId),
+            MapHassState(hassStateChange.OldState),
+            MapHassState(hassStateChange.NewState)
+        );
 
     /// <inheritdoc/>
-    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+    public IEntityState<TState, TAttributes> Map(IEntityState state) => new CachedEntityStateGeneric<TState, TAttributes>(state, this);
+
+    // /// <inheritdoc/>
+    // public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
 
     /// <inheritdoc/>
     public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity.HaContext, entity.EntityId, this);

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -1,13 +1,18 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <inheritdoc/>
-public class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<TState, TAttributes>
+public sealed class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<TState, TAttributes>
     where TAttributes : class
 {
     private readonly Func<string?, TState> _stateParser;
     private readonly Func<JsonElement?, TAttributes?> _attributesParser;
 
-    internal EntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes?> attributesParser)
+    /// <summary>
+    /// Create an EnitityStateMapper by providing parsinge functions for the state and attributes properties
+    /// </summary>
+    /// <param name="stateParser"></param>
+    /// <param name="attributesParser"></param>
+    public EntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes?> attributesParser)
     {
         _stateParser = stateParser;
         _attributesParser = attributesParser;

--- a/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EntityStateMapper.cs
@@ -32,4 +32,67 @@ public sealed class EntityStateMapper<TState, TAttributes> : IEntityStateMapper<
 
     /// <inheritdoc/>
     public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser)
+        => new EntityStateMapper<TStateNew, TAttributes>(newStateParser, _attributesParser);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>(Func<JsonElement?, TAttributesNew?> customAttributesParser)
+        where TAttributesNew : class
+        => new EntityStateMapper<TState, TAttributesNew>(_stateParser, customAttributesParser);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>()
+        where TAttributesNew : class
+        => WithAttributesAs<TAttributesNew>(DefaultEntityStateMappers.AttributesAsClass<TAttributesNew>);
+}
+
+
+/// <inheritdoc/>
+public sealed class CachedEntityStateMapper<TState, TAttributes> : IEntityStateMapper<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly Func<string?, TState> _stateParser;
+    private readonly Func<JsonElement?, TAttributes?> _attributesParser;
+
+    /// <summary>
+    /// Create an EnitityStateMapper by providing parsinge functions for the state and attributes properties
+    /// </summary>
+    /// <param name="stateParser"></param>
+    /// <param name="attributesParser"></param>
+    public CachedEntityStateMapper(Func<string?, TState> stateParser, Func<JsonElement?, TAttributes?> attributesParser)
+    {
+        _stateParser = stateParser;
+        _attributesParser = attributesParser;
+    }
+
+    /// <inheritdoc/>
+    public TState ParseState(string? rawState) => _stateParser(rawState);
+
+    /// <inheritdoc/>
+    public TAttributes? ParseAttributes(JsonElement? rawAttributes) => _attributesParser(rawAttributes);
+
+    /// <inheritdoc/>
+    public IEntityState<TState, TAttributes> Map(IEntityState state) => new CachedEntityStateGeneric<TState, TAttributes>(state, this);
+
+    /// <inheritdoc/>
+    public IEntity<TState, TAttributes> Map(IEntity entity) => new EntityGeneric<TState, TAttributes>(entity, this);
+
+    /// <inheritdoc/>
+    public IStateChange<TState, TAttributes> Map(IStateChange stateChange) => new StateChangeGeneric<TState, TAttributes>(stateChange, this);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser)
+        => new CachedEntityStateMapper<TStateNew, TAttributes>(newStateParser, _attributesParser);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>(Func<JsonElement?, TAttributesNew?> customAttributesParser)
+        where TAttributesNew : class
+        => new CachedEntityStateMapper<TState, TAttributesNew>(_stateParser, customAttributesParser);
+
+    /// <inheritdoc/>
+    public IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>()
+        where TAttributesNew : class
+        => WithAttributesAs<TAttributesNew>(DefaultEntityStateMappers.AttributesAsClass<TAttributesNew>);
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
@@ -5,31 +5,31 @@
 /// </summary>
 public static class EnumerableEntityGenericExtensions
 {
-    /// <summary>
-    /// Observable, All state changes including attributes
-    /// </summary>
-    public static IObservable<IStateChange> RawStateAllChanges(this IEnumerable<IEntity> entities) => 
-        entities.Select(t => t.RawStateAllChanges()).Merge();
+    // /// <summary>
+    // /// Observable, All state changes including attributes
+    // /// </summary>
+    // public static IObservable<IStateChange> RawStateAllChanges(this IEnumerable<IEntity> entities) => 
+    //     entities.Select(t => t.RawStateAllChanges()).Merge();
 
-    /// <summary>
-    /// Observable, All state changes. New.State != Old.State
-    /// </summary>
-    public static IObservable<IStateChange> StateChanges(this IEnumerable<IEntity> entities) =>
-        entities.RawStateAllChanges().StateChangesOnlyGeneric();
+    // /// <summary>
+    // /// Observable, All state changes. New.State != Old.State
+    // /// </summary>
+    // public static IObservable<IStateChange> StateChanges(this IEnumerable<IEntity> entities) =>
+    //     entities.RawStateAllChanges().StateChangesOnlyGeneric();
         
-    /// <summary>
-    /// Observable, All state changes including attributes
-    /// </summary>
-    public static IObservable<IStateChange<TState, TAttributes>> StateAllChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
-        where TAttributes : class =>
-        entities.Select(t => t.StateAllChanges()).Merge();
+    // /// <summary>
+    // /// Observable, All state changes including attributes
+    // /// </summary>
+    // public static IObservable<IStateChange<TState, TAttributes>> StateAllChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
+    //     where TAttributes : class =>
+    //     entities.Select(t => t.StateAllChanges()).Merge();
 
-    /// <summary>
-    /// Observable, All state changes. New.State != Old.State
-    /// </summary>
-    public static IObservable<IStateChange<TState, TAttributes>> StateChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
-        where TAttributes : class => 
-        entities.StateAllChanges().StateChangesOnlyGeneric();
+    // /// <summary>
+    // /// Observable, All state changes. New.State != Old.State
+    // /// </summary>
+    // public static IObservable<IStateChange<TState, TAttributes>> StateChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
+    //     where TAttributes : class => 
+    //     entities.StateAllChanges().StateChangesOnlyGeneric();
 
     /// <summary>
     /// Calls a service with a set of Entities as the target

--- a/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
@@ -1,0 +1,67 @@
+﻿namespace NetDaemon.HassModel.Entities;
+
+/// <summary>
+/// Provides extension methods for IEnumerable&lt;Entity&gt;
+/// </summary>
+public static class EnumerableEntityGenericExtensions
+{
+    /// <summary>
+    /// Observable, All state changes including attributes
+    /// </summary>
+    public static IObservable<IStateChange> RawStateAllChanges(this IEnumerable<IEntity> entities) => 
+        entities.Select(t => t.RawStateAllChanges()).Merge();
+
+    /// <summary>
+    /// Observable, All state changes. New.State != Old.State
+    /// </summary>
+    public static IObservable<IStateChange> StateChanges(this IEnumerable<IEntity> entities) =>
+        entities.RawStateAllChanges().StateChangesOnlyGeneric();
+        
+    /// <summary>
+    /// Observable, All state changes including attributes
+    /// </summary>
+    public static IObservable<IStateChange<TState, TAttributes>> StateAllChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
+        where TAttributes : class =>
+        entities.Select(t => t.StateAllChanges()).Merge();
+
+    /// <summary>
+    /// Observable, All state changes. New.State != Old.State
+    /// </summary>
+    public static IObservable<IStateChange<TState, TAttributes>> StateChanges<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities)
+        where TAttributes : class => 
+        entities.StateAllChanges().StateChangesOnlyGeneric();
+
+    /// <summary>
+    /// Calls a service with a set of Entities as the target
+    /// </summary>
+    /// <param name="entities">IEnumerable of Entities for which to call the service</param>
+    /// <param name="service">Name of the service to call. If the Domain of the service is the same as the domain of the Entities it can be omitted</param>
+    /// <param name="data">Data to provide</param>
+    public static void CallService(this IEnumerable<IEntity> entities, string service, object? data = null)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        
+        entities = entities.ToList();
+        
+        if (!entities.Any()) return;
+        
+        var (serviceDomain, serviceName) = service.SplitAtDot();
+
+        if (serviceDomain == null)
+        {
+            var domainsFromEntity = entities.Select(e => e.EntityId.SplitAtDot().Left).Distinct().Take(2).ToArray();
+            if (domainsFromEntity.Length != 1) throw new InvalidOperationException($"Cannot call service {service} for entities that do not have the same domain");
+            
+            serviceDomain = domainsFromEntity.First()!;
+        }
+        
+        // Usually each Entity will have the same IHaContext and domain, but just in case its not, group by the context and domain and call the
+        // service for each group separately
+        var serviceCalls = entities.GroupBy(e => e.HaContext);
+        
+        foreach (var group in serviceCalls)
+        {
+            group.Key.CallService(serviceDomain, serviceName, new ServiceTarget { EntityIds = group.Select(e => e.EntityId).ToList() }, data);
+        }
+    }
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/EnumerableEntityGenericExtensions.cs
@@ -37,7 +37,8 @@ public static class EnumerableEntityGenericExtensions
     /// <param name="entities">IEnumerable of Entities for which to call the service</param>
     /// <param name="service">Name of the service to call. If the Domain of the service is the same as the domain of the Entities it can be omitted</param>
     /// <param name="data">Data to provide</param>
-    public static void CallService(this IEnumerable<IEntity> entities, string service, object? data = null)
+    public static void CallService<TState, TAttributes>(this IEnumerable<IEntity<TState, TAttributes>> entities, string service, object? data = null)
+        where TAttributes : class
     {
         ArgumentNullException.ThrowIfNull(service);
         

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
@@ -1,7 +1,8 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <summary>Represents a Home Assistant entity with its state, changes and services</summary>
-public interface IEntity
+public interface IEntity<TState, TAttributes>
+    where TAttributes : class
 {
     /// <summary>
     /// The IHAContext
@@ -14,36 +15,11 @@ public interface IEntity
     string EntityId { get; }
 
     /// <summary>
-    /// The full state of the entity in its raw form
-    /// </summary>
-    /// <value></value>
-    IEntityState? RawEntityState { get; }
-
-    /// <summary>The current state of this Entity as a raw string</summary>
-    string? RawState { get; }
-    
-    // /// <summary>
-    // /// Observable, All state changes including attributes
-    // /// </summary>
-    // IObservable<IStateChange> RawStateAllChanges();
-
-    // /// <summary>
-    // /// Observable, All state changes. New.State!=Old.State
-    // /// </summary>
-    // IObservable<IStateChange> RawStateChanges();
-
-    /// <summary>
     /// Calls a service using this entity as the target
     /// </summary>
     /// <param name="service">Name of the service to call. If the Domain of the service is the same as the domain of the Entity it can be omitted</param>
     /// <param name="data">Data to provide</param>
     void CallService(string service, object? data = null);
-}
-
-/// <summary>Represents a Home Assistant entity with its state, changes and services</summary>
-public interface IEntity<TState, TAttributes> : IEntity
-    where TAttributes : class
-{
     /// <summary>
     /// The full state of this Entity
     /// </summary>
@@ -72,29 +48,4 @@ public interface IEntity<TState, TAttributes> : IEntity
     /// Observable, All state changes. New.State!=Old.State
     /// </summary>
     IObservable<IStateChange<TState, TAttributes>> StateChanges();
-
-    /// <summary>
-    /// Get a new IEntity with new state type mapping
-    /// </summary>
-    /// <param name="newStateParser"></param>
-    /// <typeparam name="TStateNew"></typeparam>
-    /// <returns></returns>
-    IEntity<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser);
-
-    /// <summary>
-    /// Get a new IEntity with a new attributes class mapping
-    /// </summary>
-    /// <param name="newAttributesParser"></param>
-    /// <typeparam name="TAttributesNew"></typeparam>
-    /// <returns></returns>
-    IEntity<TState, TAttributesNew> WithAttributesAs<TAttributesNew>(Func<JsonElement?, TAttributesNew> newAttributesParser)
-        where TAttributesNew : class;
-
-    /// <summary>
-    /// Get a new IEntity with a new attributes class mapping using the default parser
-    /// </summary>
-    /// <typeparam name="TAttributesNew"></typeparam>
-    /// <returns></returns>
-    IEntity<TState, TAttributesNew> WithAttributesAs<TAttributesNew>()
-        where TAttributesNew : class;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
@@ -56,6 +56,12 @@ public interface IEntity<TState, TAttributes> : IEntity
     /// The current Attributes of this Entity
     /// </summary>
     TAttributes? Attributes { get; }
+
+    /// <summary>
+    /// The mapper from the raw state and attributes to the strong types
+    /// </summary>
+    /// <value></value>
+    IEntityStateMapper<TState, TAttributes> EntityStateMapper { get; }
     
     /// <summary>
     /// Observable, All state changes including attributes
@@ -66,4 +72,29 @@ public interface IEntity<TState, TAttributes> : IEntity
     /// Observable, All state changes. New.State!=Old.State
     /// </summary>
     IObservable<IStateChange<TState, TAttributes>> StateChanges();
+
+    /// <summary>
+    /// Get a new IEntity with new state type mapping
+    /// </summary>
+    /// <param name="newStateParser"></param>
+    /// <typeparam name="TStateNew"></typeparam>
+    /// <returns></returns>
+    IEntity<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser);
+
+    /// <summary>
+    /// Get a new IEntity with a new attributes class mapping
+    /// </summary>
+    /// <param name="newAttributesParser"></param>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <returns></returns>
+    IEntity<TState, TAttributesNew> WithAttributesAs<TAttributesNew>(Func<JsonElement?, TAttributesNew> newAttributesParser)
+        where TAttributesNew : class;
+
+    /// <summary>
+    /// Get a new IEntity with a new attributes class mapping using the default parser
+    /// </summary>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <returns></returns>
+    IEntity<TState, TAttributesNew> WithAttributesAs<TAttributesNew>()
+        where TAttributesNew : class;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
@@ -13,6 +13,10 @@ public interface IEntity
     /// </summary>
     string EntityId { get; }
 
+    /// <summary>
+    /// The full state of the entity in its raw form
+    /// </summary>
+    /// <value></value>
     IEntityState? RawEntityState { get; }
 
     /// <summary>The current state of this Entity as a raw string</summary>
@@ -51,7 +55,7 @@ public interface IEntity<TState, TAttributes> : IEntity
     /// <summary>
     /// The current Attributes of this Entity
     /// </summary>
-    TAttributes Attributes { get; }
+    TAttributes? Attributes { get; }
     
     /// <summary>
     /// Observable, All state changes including attributes

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
@@ -1,0 +1,65 @@
+namespace NetDaemon.HassModel.Entities;
+
+/// <summary>Represents a Home Assistant entity with its state, changes and services</summary>
+public interface IEntity
+{
+    /// <summary>
+    /// The IHAContext
+    /// </summary>
+    IHaContext HaContext { get; }
+
+    /// <summary>
+    /// Entity id being handled by this entity
+    /// </summary>
+    string EntityId { get; }
+
+    IEntityState? RawEntityState { get; }
+
+    /// <summary>The current state of this Entity as a raw string</summary>
+    string? RawState { get; }
+    
+    /// <summary>
+    /// Observable, All state changes including attributes
+    /// </summary>
+    IObservable<IStateChange> RawStateAllChanges();
+
+    /// <summary>
+    /// Observable, All state changes. New.State!=Old.State
+    /// </summary>
+    IObservable<IStateChange> RawStateChanges();
+
+    /// <summary>
+    /// Calls a service using this entity as the target
+    /// </summary>
+    /// <param name="service">Name of the service to call. If the Domain of the service is the same as the domain of the Entity it can be omitted</param>
+    /// <param name="data">Data to provide</param>
+    void CallService(string service, object? data = null);
+}
+
+/// <summary>Represents a Home Assistant entity with its state, changes and services</summary>
+public interface IEntity<TState, TAttributes> : IEntity
+    where TAttributes : class
+{
+    /// <summary>
+    /// The full state of this Entity
+    /// </summary>
+    IEntityState<TState, TAttributes>? EntityState { get; }
+    
+    /// <summary>The current state of this Entity</summary>
+    TState State { get; }
+
+    /// <summary>
+    /// The current Attributes of this Entity
+    /// </summary>
+    TAttributes Attributes { get; }
+    
+    /// <summary>
+    /// Observable, All state changes including attributes
+    /// </summary>
+    IObservable<IStateChange<TState, TAttributes>> StateAllChanges();
+
+    /// <summary>
+    /// Observable, All state changes. New.State!=Old.State
+    /// </summary>
+    IObservable<IStateChange<TState, TAttributes>> StateChanges();
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntity.cs
@@ -22,15 +22,15 @@ public interface IEntity
     /// <summary>The current state of this Entity as a raw string</summary>
     string? RawState { get; }
     
-    /// <summary>
-    /// Observable, All state changes including attributes
-    /// </summary>
-    IObservable<IStateChange> RawStateAllChanges();
+    // /// <summary>
+    // /// Observable, All state changes including attributes
+    // /// </summary>
+    // IObservable<IStateChange> RawStateAllChanges();
 
-    /// <summary>
-    /// Observable, All state changes. New.State!=Old.State
-    /// </summary>
-    IObservable<IStateChange> RawStateChanges();
+    // /// <summary>
+    // /// Observable, All state changes. New.State!=Old.State
+    // /// </summary>
+    // IObservable<IStateChange> RawStateChanges();
 
     /// <summary>
     /// Calls a service using this entity as the target

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityFactory.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityFactory.cs
@@ -1,0 +1,15 @@
+namespace NetDaemon.HassModel.Entities;
+
+/// <summary>
+/// Factory for creating strongly typed generic IEntity instances
+/// </summary>
+public interface IEntityFactory
+{
+    /// <summary>
+    /// Create a generic IEntity instance where the state is parsed as TState and the attributes are parsed as TAttributes
+    /// </summary>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TAttributes"></typeparam>
+    IEntity<TState, TAttributes> CreateIEntity<TState, TAttributes>(string entityId, IEntityStateMapper<TState, TAttributes> mapper)
+        where TAttributes : class;
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
@@ -1,0 +1,24 @@
+namespace NetDaemon.HassModel.Entities;
+
+public interface IEntityState
+{
+    string EntityId { get; }
+
+    string? RawState { get; }
+
+    JsonElement? AttributesJson { get; }
+
+    DateTime? LastChanged { get; }
+
+    DateTime? LastUpdated { get; }
+
+    Context? Context { get; }
+}
+
+public interface IEntityState<TState, TAttributes> : IEntityState
+    where TAttributes : class
+{
+    TState State { get; }
+
+    TAttributes Attributes { get; }
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
@@ -1,24 +1,64 @@
 namespace NetDaemon.HassModel.Entities;
 
+/// <summary>
+/// Detailec state information
+/// </summary>
 public interface IEntityState
 {
+    /// <summary>
+    /// Unique id of the entity
+    /// </summary>
+    /// <value></value>
     string EntityId { get; }
 
+    /// <summary>
+    /// The raw state of the entity as the original nullable string
+    /// </summary>
+    /// <value></value>
     string? RawState { get; }
 
+    /// <summary>
+    /// The raw attributes as the original JSON
+    /// </summary>
+    /// <value></value>
     JsonElement? AttributesJson { get; }
 
+    /// <summary>
+    /// When the state or attributes last changed
+    /// </summary>
+    /// <value></value>
     DateTime? LastChanged { get; }
 
+    /// <summary>
+    /// When the state or attributes were last update (even if they didn't change)
+    /// </summary>
+    /// <value></value>
     DateTime? LastUpdated { get; }
 
+    /// <summary>
+    /// Home Assistant Context
+    /// </summary>
+    /// <value></value>
     Context? Context { get; }
 }
 
+/// <summary>
+/// Generic EntityState with specific types of State and Attributes
+/// </summary>
+/// <typeparam name="TState">Type of the State property</typeparam>
+/// <typeparam name="TAttributes">Type of the Attributes property</typeparam>
 public interface IEntityState<TState, TAttributes> : IEntityState
     where TAttributes : class
 {
+    /// <summary>
+    /// The state of the entity as the type TState
+    /// </summary>
+    /// <value></value>
     TState State { get; }
 
-    TAttributes Attributes { get; }
+    /// <summary>
+    /// The attributes of the entity as the class TAttributes (possibly null)
+    /// </summary>
+    /// <value></value>
+    TAttributes? Attributes { get; }
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
@@ -1,7 +1,7 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <summary>
-/// Detailec state information
+/// Detailed state information
 /// </summary>
 public interface IEntityState
 {

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityState.cs
@@ -1,9 +1,12 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <summary>
-/// Detailed state information
+/// Generic EntityState with specific types of State and Attributes
 /// </summary>
-public interface IEntityState
+/// <typeparam name="TState">Type of the State property</typeparam>
+/// <typeparam name="TAttributes">Type of the Attributes property</typeparam>
+public interface IEntityState<TState, TAttributes>
+    where TAttributes : class
 {
     /// <summary>
     /// Unique id of the entity
@@ -40,16 +43,6 @@ public interface IEntityState
     /// </summary>
     /// <value></value>
     Context? Context { get; }
-}
-
-/// <summary>
-/// Generic EntityState with specific types of State and Attributes
-/// </summary>
-/// <typeparam name="TState">Type of the State property</typeparam>
-/// <typeparam name="TAttributes">Type of the Attributes property</typeparam>
-public interface IEntityState<TState, TAttributes> : IEntityState
-    where TAttributes : class
-{
     /// <summary>
     /// The state of the entity as the type TState
     /// </summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -30,18 +30,26 @@ public interface IEntityStateMapper<TState, TAttributes>
     IEntityState<TState, TAttributes> Map(IEntityState state);
 
     /// <summary>
-    /// Map a raw entity into a strongly typed one
+    /// Map a raw state change object into a strongly typed one
+    /// </summary>
+    /// <param name="stateChange"></param>
+    /// <returns></returns>
+    IStateChange<TState, TAttributes> Map(IStateChange stateChange);
+
+    /// <summary>
+    /// Map a raw state change object into a strongly typed one
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
     IEntity<TState, TAttributes> Map(IEntity entity);
 
     /// <summary>
-    /// Map a raw state change object into a strongly typed one
+    /// Create a new Entity instance
     /// </summary>
-    /// <param name="stateChange"></param>
+    /// <param name="haContext"></param>
+    /// <param name="entityId"></param>
     /// <returns></returns>
-    IStateChange<TState, TAttributes> Map(IStateChange stateChange);
+    IEntity<TState, TAttributes> Entity(IHaContext haContext, string entityId);
 
     /// <summary>
     /// Create a new IEntityStateMapper that has a new state type and parser

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -20,7 +20,7 @@ public interface IEntityStateMapper<TState, TAttributes>
     /// </summary>
     /// <param name="rawAttributes"></param>
     /// <returns></returns>
-    TAttributes ParseAttributes(JsonElement? rawAttributes);
+    TAttributes? ParseAttributes(JsonElement? rawAttributes);
 
     /// <summary>
     /// Map a raw entity state object into a strongly typed one

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -37,13 +37,6 @@ public interface IEntityStateMapper<TState, TAttributes>
     /// <returns></returns>
     IStateChange<TState, TAttributes> MapHassStateChange(IHaContext haContext, HassStateChangedEventData hassStateChange);
 
-    /// <summary>
-    /// Map a raw entity state object into a strongly typed one
-    /// </summary>
-    /// <param name="state"></param>
-    /// <returns></returns>
-    IEntityState<TState, TAttributes> Map(IEntityState state);
-
     // /// <summary>
     // /// Map a raw state change object into a strongly typed one
     // /// </summary>
@@ -56,7 +49,8 @@ public interface IEntityStateMapper<TState, TAttributes>
     /// </summary>
     /// <param name="entity"></param>
     /// <returns></returns>
-    IEntity<TState, TAttributes> Map(IEntity entity);
+    IEntity<TState, TAttributes> Map<TStateOld, TAttributesOld>(IEntity<TStateOld, TAttributesOld> entity)
+        where TAttributesOld : class;
 
     /// <summary>
     /// Create a new Entity instance

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -42,4 +42,31 @@ public interface IEntityStateMapper<TState, TAttributes>
     /// <param name="stateChange"></param>
     /// <returns></returns>
     IStateChange<TState, TAttributes> Map(IStateChange stateChange);
+
+    /// <summary>
+    /// Create a new IEntityStateMapper that has a new state type and parser
+    /// with the same attributes clsss
+    /// </summary>
+    /// <param name="newStateParser"></param>
+    /// <typeparam name="TStateNew"></typeparam>
+    /// <returns></returns>
+    IEntityStateMapper<TStateNew, TAttributes> WithStateAs<TStateNew>(Func<string?, TStateNew> newStateParser);
+
+    /// <summary>
+    /// Create a new IEntityStateMapper that has the same state type and parser
+    /// with a new attributes class
+    /// </summary>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <returns></returns>
+    IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>(Func<JsonElement?, TAttributesNew?> customAttributesParser)
+        where TAttributesNew : class;
+
+    /// <summary>
+    /// Create a new IEntityStateMapper that has the same state type and parser
+    /// with a new attributes class using the default attributes parser
+    /// </summary>
+    /// <typeparam name="TAttributesNew"></typeparam>
+    /// <returns></returns>
+    IEntityStateMapper<TState, TAttributesNew> WithAttributesAs<TAttributesNew>()
+        where TAttributesNew : class;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -23,18 +23,33 @@ public interface IEntityStateMapper<TState, TAttributes>
     TAttributes? ParseAttributes(JsonElement? rawAttributes);
 
     /// <summary>
+    /// Map a HassState object to IEntityState
+    /// </summary>
+    /// <param name="hassState"></param>
+    /// <returns></returns>
+    IEntityState<TState, TAttributes>? MapHassState(HassState? hassState);
+
+    /// <summary>
+    /// Map a HassStateChangedEventData object to IStateChange
+    /// </summary>
+    /// <param name="haContext"></param>
+    /// <param name="hassStateChange"></param>
+    /// <returns></returns>
+    IStateChange<TState, TAttributes> MapHassStateChange(IHaContext haContext, HassStateChangedEventData hassStateChange);
+
+    /// <summary>
     /// Map a raw entity state object into a strongly typed one
     /// </summary>
     /// <param name="state"></param>
     /// <returns></returns>
     IEntityState<TState, TAttributes> Map(IEntityState state);
 
-    /// <summary>
-    /// Map a raw state change object into a strongly typed one
-    /// </summary>
-    /// <param name="stateChange"></param>
-    /// <returns></returns>
-    IStateChange<TState, TAttributes> Map(IStateChange stateChange);
+    // /// <summary>
+    // /// Map a raw state change object into a strongly typed one
+    // /// </summary>
+    // /// <param name="stateChange"></param>
+    // /// <returns></returns>
+    // IStateChange<TState, TAttributes> Map(IStateChange stateChange);
 
     /// <summary>
     /// Map a raw state change object into a strongly typed one

--- a/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IEntityStateMapper.cs
@@ -1,0 +1,45 @@
+namespace NetDaemon.HassModel.Entities;
+
+/// <summary>
+/// Maps the raw state and attributes of an IEntity object to strongly typed objects / values
+/// </summary>
+/// <typeparam name="TState">A type that is deserializable from a nullable string to hold the state of the entity</typeparam>
+/// <typeparam name="TAttributes">Json deserializable reference type to hold the entities attributes</typeparam>
+public interface IEntityStateMapper<TState, TAttributes>
+    where TAttributes : class
+{
+    /// <summary>
+    /// Parse a nullable string into the state type
+    /// </summary>
+    /// <param name="rawState"></param>
+    /// <returns></returns>
+    TState ParseState(string? rawState);
+
+    /// <summary>
+    /// Parse a nullable JsonElement into the strongly type attribute class
+    /// </summary>
+    /// <param name="rawAttributes"></param>
+    /// <returns></returns>
+    TAttributes ParseAttributes(JsonElement? rawAttributes);
+
+    /// <summary>
+    /// Map a raw entity state object into a strongly typed one
+    /// </summary>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    IEntityState<TState, TAttributes> Map(IEntityState state);
+
+    /// <summary>
+    /// Map a raw entity into a strongly typed one
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns></returns>
+    IEntity<TState, TAttributes> Map(IEntity entity);
+
+    /// <summary>
+    /// Map a raw state change object into a strongly typed one
+    /// </summary>
+    /// <param name="stateChange"></param>
+    /// <returns></returns>
+    IStateChange<TState, TAttributes> Map(IStateChange stateChange);
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
@@ -1,18 +1,46 @@
 namespace NetDaemon.HassModel.Entities;
 
+/// <summary>
+/// Represents a state change event for an entity
+/// </summary>
 public interface IStateChange
 {
+    /// <summary>
+    /// The entity associated with the state change
+    /// </summary>
+    /// <value></value>
     IEntity Entity { get; }
 
+    /// <summary>
+    /// The old raw state of the entity
+    /// </summary>
+    /// <value></value>
     IEntityState? RawOld { get; }
 
+    /// <summary>
+    /// The new raw state of the entity
+    /// </summary>
+    /// <value></value>
     IEntityState? RawNew { get; }
 }
 
+/// <summary>
+/// Represents a state change event for a strongly typed entity and state
+/// </summary>
+/// <typeparam name="TState"></typeparam>
+/// <typeparam name="TAttributes"></typeparam>
 public interface IStateChange<TState, TAttributes> : IStateChange
     where TAttributes : class
 {
+    /// <summary>
+    /// The strongly typed old state
+    /// </summary>
+    /// <value></value>
     IEntityState<TState, TAttributes>? Old { get; }
 
+    /// <summary>
+    /// The strongly typed new state
+    /// </summary>
+    /// <value></value>
     IEntityState<TState, TAttributes>? New { get; }
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
@@ -9,7 +9,7 @@ public interface IStateChange
     /// The entity associated with the state change
     /// </summary>
     /// <value></value>
-    IEntity Entity { get; }
+    IEntity RawEntity { get; }
 
     /// <summary>
     /// The old raw state of the entity
@@ -32,6 +32,12 @@ public interface IStateChange
 public interface IStateChange<TState, TAttributes> : IStateChange
     where TAttributes : class
 {
+    /// <summary>
+    /// The strongly typed entity object
+    /// </summary>
+    /// <value></value>
+    IEntity<TState, TAttributes> Entity { get; }
+
     /// <summary>
     /// The strongly typed old state
     /// </summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
@@ -1,0 +1,18 @@
+namespace NetDaemon.HassModel.Entities;
+
+public interface IStateChange
+{
+    IEntity Entity { get; }
+
+    IEntityState? RawOld { get; }
+
+    IEntityState? RawNew { get; }
+}
+
+public interface IStateChange<TState, TAttributes> : IStateChange
+    where TAttributes : class
+{
+    IEntityState<TState, TAttributes>? Old { get; }
+
+    IEntityState<TState, TAttributes>? New { get; }
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/IStateChange.cs
@@ -1,35 +1,11 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <summary>
-/// Represents a state change event for an entity
-/// </summary>
-public interface IStateChange
-{
-    /// <summary>
-    /// The entity associated with the state change
-    /// </summary>
-    /// <value></value>
-    IEntity RawEntity { get; }
-
-    /// <summary>
-    /// The old raw state of the entity
-    /// </summary>
-    /// <value></value>
-    IEntityState? RawOld { get; }
-
-    /// <summary>
-    /// The new raw state of the entity
-    /// </summary>
-    /// <value></value>
-    IEntityState? RawNew { get; }
-}
-
-/// <summary>
 /// Represents a state change event for a strongly typed entity and state
 /// </summary>
 /// <typeparam name="TState"></typeparam>
 /// <typeparam name="TAttributes"></typeparam>
-public interface IStateChange<TState, TAttributes> : IStateChange
+public interface IStateChange<TState, TAttributes>
     where TAttributes : class
 {
     /// <summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
@@ -1,39 +1,49 @@
 namespace NetDaemon.HassModel.Entities;
 
-public record StateChangeGeneric : IStateChange
+/// <inheritdoc/>
+public sealed record StateChangeGeneric : IStateChange
 {
+    /// <inheritdoc/>
     public required IEntity Entity { get; init; }
 
+    /// <inheritdoc/>
     public IEntityState? RawOld { get; init; }
 
+    /// <inheritdoc/>
     public IEntityState? RawNew { get; init; }
 }
 
-public record StateChangeGeneric<TState, TAttributes> : IStateChange<TState, TAttributes>
+/// <inheritdoc/>
+public sealed record StateChangeGeneric<TState, TAttributes> : IStateChange<TState, TAttributes>
     where TAttributes : class
 {
     private readonly IStateChange _stateChange;
     private readonly IEntityStateMapper<TState, TAttributes> _mapper;
 
-    public StateChangeGeneric(IStateChange stateChange, IEntityStateMapper<TState, TAttributes> mapper)
+    internal StateChangeGeneric(IStateChange stateChange, IEntityStateMapper<TState, TAttributes> mapper)
     {
         _stateChange = stateChange;
         _mapper = mapper;
     }
 
+    /// <inheritdoc/>
     public IEntityState<TState, TAttributes>? Old =>
         _stateChange.RawOld is null
             ? null
             : _mapper.Map(_stateChange.RawOld);
 
+    /// <inheritdoc/>
     public IEntityState<TState, TAttributes>? New =>
         _stateChange.RawNew is null
             ? null
             : _mapper.Map(_stateChange.RawNew);
 
+    /// <inheritdoc/>
     public IEntity Entity => _stateChange.Entity;
 
+    /// <inheritdoc/>
     public IEntityState? RawOld => _stateChange.RawOld;
 
+    /// <inheritdoc/>
     public IEntityState? RawNew => _stateChange.RawNew;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
@@ -1,17 +1,12 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <inheritdoc/>
-public sealed record StateChangeGeneric : IStateChange
-{
-    /// <inheritdoc/>
-    public required IEntity Entity { get; init; }
-
-    /// <inheritdoc/>
-    public IEntityState? RawOld { get; init; }
-
-    /// <inheritdoc/>
-    public IEntityState? RawNew { get; init; }
-}
+public sealed record StateChangeGeneric
+(
+    IEntity Entity,
+    IEntityState? RawOld,
+    IEntityState? RawNew
+) : IStateChange;
 
 /// <inheritdoc/>
 public sealed record StateChangeGeneric<TState, TAttributes> : IStateChange<TState, TAttributes>

--- a/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
@@ -1,44 +1,15 @@
 namespace NetDaemon.HassModel.Entities;
 
 /// <inheritdoc/>
-public sealed record StateChangeGeneric
+public sealed record StateChangeGeneric<TState, TAttributes>
 (
-    IEntity Entity,
-    IEntityState? RawOld,
-    IEntityState? RawNew
-) : IStateChange;
-
-/// <inheritdoc/>
-public sealed record StateChangeGeneric<TState, TAttributes> : IStateChange<TState, TAttributes>
+    IEntity<TState, TAttributes> Entity,
+    IEntityState<TState, TAttributes>? Old,
+    IEntityState<TState, TAttributes>? New
+) : IStateChange<TState, TAttributes>
     where TAttributes : class
 {
-    private readonly IStateChange _stateChange;
-    private readonly IEntityStateMapper<TState, TAttributes> _mapper;
-
-    internal StateChangeGeneric(IStateChange stateChange, IEntityStateMapper<TState, TAttributes> mapper)
-    {
-        _stateChange = stateChange;
-        _mapper = mapper;
-    }
-
-    /// <inheritdoc/>
-    public IEntityState<TState, TAttributes>? Old =>
-        _stateChange.RawOld is null
-            ? null
-            : _mapper.Map(_stateChange.RawOld);
-
-    /// <inheritdoc/>
-    public IEntityState<TState, TAttributes>? New =>
-        _stateChange.RawNew is null
-            ? null
-            : _mapper.Map(_stateChange.RawNew);
-
-    /// <inheritdoc/>
-    public IEntity Entity => _stateChange.Entity;
-
-    /// <inheritdoc/>
-    public IEntityState? RawOld => _stateChange.RawOld;
-
-    /// <inheritdoc/>
-    public IEntityState? RawNew => _stateChange.RawNew;
+    IEntity IStateChange.RawEntity => Entity;
+    IEntityState? IStateChange.RawOld => Old;
+    IEntityState? IStateChange.RawNew => New;
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
@@ -1,0 +1,39 @@
+namespace NetDaemon.HassModel.Entities;
+
+public record StateChangeGeneric : IStateChange
+{
+    public required IEntity Entity { get; init; }
+
+    public IEntityState? RawOld { get; init; }
+
+    public IEntityState? RawNew { get; init; }
+}
+
+public record StateChangeGeneric<TState, TAttributes> : IStateChange<TState, TAttributes>
+    where TAttributes : class
+{
+    private readonly IStateChange _stateChange;
+    private readonly IEntityStateMapper<TState, TAttributes> _mapper;
+
+    public StateChangeGeneric(IStateChange stateChange, IEntityStateMapper<TState, TAttributes> mapper)
+    {
+        _stateChange = stateChange;
+        _mapper = mapper;
+    }
+
+    public IEntityState<TState, TAttributes>? Old =>
+        _stateChange.RawOld is null
+            ? null
+            : _mapper.Map(_stateChange.RawOld);
+
+    public IEntityState<TState, TAttributes>? New =>
+        _stateChange.RawNew is null
+            ? null
+            : _mapper.Map(_stateChange.RawNew);
+
+    public IEntity Entity => _stateChange.Entity;
+
+    public IEntityState? RawOld => _stateChange.RawOld;
+
+    public IEntityState? RawNew => _stateChange.RawNew;
+}

--- a/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/StateChangeGeneric.cs
@@ -7,9 +7,4 @@ public sealed record StateChangeGeneric<TState, TAttributes>
     IEntityState<TState, TAttributes>? Old,
     IEntityState<TState, TAttributes>? New
 ) : IStateChange<TState, TAttributes>
-    where TAttributes : class
-{
-    IEntity IStateChange.RawEntity => Entity;
-    IEntityState? IStateChange.RawOld => Old;
-    IEntityState? IStateChange.RawNew => New;
-}
+    where TAttributes : class;

--- a/src/HassModel/NetDeamon.HassModel/IHaContext.cs
+++ b/src/HassModel/NetDeamon.HassModel/IHaContext.cs
@@ -15,16 +15,22 @@ public interface IHaContext
     /// </summary>
     IObservable<StateChange> StateAllChanges();
 
+    IObservable<IStateChange> StateAllChangesGeneric();
+
     /// <summary>
     /// Get state for a single entity
     /// </summary>
     /// <param name="entityId"></param>
     EntityState? GetState(string entityId);
 
+    IEntityState? GetStateGeneric(string entityId);
+
     /// <summary>
     /// Gets all the entities in HomeAssistant
     /// </summary>
     IReadOnlyList<Entity> GetAllEntities();
+
+    IReadOnlyList<IEntity> GetAllEntitiesGeneric();
 
     /// <summary>
     /// Calls a service in Home Assistant

--- a/src/HassModel/NetDeamon.HassModel/IHaContext.cs
+++ b/src/HassModel/NetDeamon.HassModel/IHaContext.cs
@@ -19,7 +19,7 @@ public interface IHaContext
     /// The observable state stream, all changes including attributes
     /// </summary>
     /// <returns></returns>
-    IObservable<IStateChange> StateAllChangesGeneric();
+    IObservable<T> StateAllChangesGeneric<T>(Func<IHaContext, HassStateChangedEventData, T> mapper);
 
     /// <summary>
     /// Get state for a single entity
@@ -31,8 +31,9 @@ public interface IHaContext
     /// Get state for a single entity
     /// </summary>
     /// <param name="entityId"></param>
+    /// <param name="mapper">A function to convert a HassState object to the required return type</param>
     /// <returns></returns>
-    IEntityState? GetStateGeneric(string entityId);
+    T GetState<T>(string entityId, Func<HassState?, T> mapper);
 
     /// <summary>
     /// Gets all the entities in HomeAssistant

--- a/src/HassModel/NetDeamon.HassModel/IHaContext.cs
+++ b/src/HassModel/NetDeamon.HassModel/IHaContext.cs
@@ -19,7 +19,7 @@ public interface IHaContext
     /// The observable state stream, all changes including attributes
     /// </summary>
     /// <returns></returns>
-    IObservable<T> StateAllChangesGeneric<T>(Func<IHaContext, HassStateChangedEventData, T> mapper);
+    IObservable<HassStateChangedEventData> HassStateAllChanges();
 
     /// <summary>
     /// Get state for a single entity
@@ -28,12 +28,11 @@ public interface IHaContext
     EntityState? GetState(string entityId);
 
     /// <summary>
-    /// Get state for a single entity
+    /// Get HassState for a single entity
     /// </summary>
     /// <param name="entityId"></param>
-    /// <param name="mapper">A function to convert a HassState object to the required return type</param>
     /// <returns></returns>
-    T GetState<T>(string entityId, Func<HassState?, T> mapper);
+    HassState? GetHassState(string entityId);
 
     /// <summary>
     /// Gets all the entities in HomeAssistant
@@ -44,7 +43,7 @@ public interface IHaContext
     /// Gets all the entities in HomeAssistant
     /// </summary>
     /// <returns></returns>
-    IReadOnlyList<IEntity> GetAllEntitiesGeneric();
+    IEnumerable<string> GetAllEntityIds();
 
     /// <summary>
     /// Calls a service in Home Assistant

--- a/src/HassModel/NetDeamon.HassModel/IHaContext.cs
+++ b/src/HassModel/NetDeamon.HassModel/IHaContext.cs
@@ -15,6 +15,10 @@ public interface IHaContext
     /// </summary>
     IObservable<StateChange> StateAllChanges();
 
+    /// <summary>
+    /// The observable state stream, all changes including attributes
+    /// </summary>
+    /// <returns></returns>
     IObservable<IStateChange> StateAllChangesGeneric();
 
     /// <summary>
@@ -23,6 +27,11 @@ public interface IHaContext
     /// <param name="entityId"></param>
     EntityState? GetState(string entityId);
 
+    /// <summary>
+    /// Get state for a single entity
+    /// </summary>
+    /// <param name="entityId"></param>
+    /// <returns></returns>
     IEntityState? GetStateGeneric(string entityId);
 
     /// <summary>
@@ -30,6 +39,10 @@ public interface IHaContext
     /// </summary>
     IReadOnlyList<Entity> GetAllEntities();
 
+    /// <summary>
+    /// Gets all the entities in HomeAssistant
+    /// </summary>
+    /// <returns></returns>
     IReadOnlyList<IEntity> GetAllEntitiesGeneric();
 
     /// <summary>

--- a/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
@@ -65,7 +65,7 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
 
     public IReadOnlyList<IEntity> GetAllEntitiesGeneric()
     {
-        return _entityStateCache.AllEntityIds.Select(id => new EntityGeneric(this, id)).ToList();
+        return _entityStateCache.AllEntityIds.Select(id => DefaultEntityStateMappers.Base.Entity(this, id)).ToList();
     }
 
     public void CallService(string domain, string service, ServiceTarget? target = null, object? data = null)

--- a/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
@@ -48,6 +48,11 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
         return _entityStateCache.GetState(entityId).Map();
     }
 
+    public IEntityState? GetStateGeneric(string entityId)
+    {
+        return _entityStateCache.GetState(entityId).MapGeneric();
+    }
+
     public Area? GetAreaFromEntityId(string entityId)
     {
         return _entityAreaCache.GetArea(entityId)?.Map();
@@ -56,6 +61,11 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
     public IReadOnlyList<Entity> GetAllEntities()
     {
         return _entityStateCache.AllEntityIds.Select(id => new Entity(this, id)).ToList();
+    }
+
+    public IReadOnlyList<IEntity> GetAllEntitiesGeneric()
+    {
+        return _entityStateCache.AllEntityIds.Select(id => new EntityGeneric(this, id)).ToList();
     }
 
     public void CallService(string domain, string service, ServiceTarget? target = null, object? data = null)
@@ -69,6 +79,14 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
             n.EventType == "state_changed")
             .Select(n => n.ToStateChangedEvent()!)
             .Select(e => e.Map(this));
+    }
+
+    public IObservable<IStateChange> StateAllChangesGeneric()
+    {
+        return _queuedObservable.Where(n =>
+            n.EventType == "state_changed")
+            .Select(n => n.ToStateChangedEvent()!)
+            .Select(e => e.MapGeneric(this));
     }
 
     public IObservable<Event> Events => _queuedObservable

--- a/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
@@ -48,9 +48,9 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
         return _entityStateCache.GetState(entityId).Map();
     }
 
-    public T GetState<T>(string entityId, Func<HassState?, T> mapper)
+    public HassState? GetHassState(string entityId)
     {
-        return mapper(_entityStateCache.GetState(entityId));
+        return _entityStateCache.GetState(entityId);
     }
 
     public Area? GetAreaFromEntityId(string entityId)
@@ -63,9 +63,9 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
         return _entityStateCache.AllEntityIds.Select(id => new Entity(this, id)).ToList();
     }
 
-    public IReadOnlyList<IEntity> GetAllEntitiesGeneric()
+    public IEnumerable<string> GetAllEntityIds()
     {
-        return _entityStateCache.AllEntityIds.Select(id => DefaultEntityStateMappers.Base.Entity(this, id)).ToList();
+        return _entityStateCache.AllEntityIds;
     }
 
     public void CallService(string domain, string service, ServiceTarget? target = null, object? data = null)
@@ -81,12 +81,11 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
             .Select(e => e.Map(this));
     }
 
-    public IObservable<T> StateAllChangesGeneric<T>(Func<IHaContext, HassStateChangedEventData, T> mapper)
+    public IObservable<HassStateChangedEventData> HassStateAllChanges()
     {
         return _queuedObservable.Where(n =>
             n.EventType == "state_changed")
-            .Select(n => n.ToStateChangedEvent()!)
-            .Select(e => mapper(this, e));
+            .Select(n => n.ToStateChangedEvent()!);
     }
 
     public IObservable<Event> Events => _queuedObservable

--- a/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/AppScopedHaContextProvider.cs
@@ -48,9 +48,9 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
         return _entityStateCache.GetState(entityId).Map();
     }
 
-    public IEntityState? GetStateGeneric(string entityId)
+    public T GetState<T>(string entityId, Func<HassState?, T> mapper)
     {
-        return _entityStateCache.GetState(entityId).MapGeneric();
+        return mapper(_entityStateCache.GetState(entityId));
     }
 
     public Area? GetAreaFromEntityId(string entityId)
@@ -81,12 +81,12 @@ internal class AppScopedHaContextProvider : IHaContext, IAsyncDisposable
             .Select(e => e.Map(this));
     }
 
-    public IObservable<IStateChange> StateAllChangesGeneric()
+    public IObservable<T> StateAllChangesGeneric<T>(Func<IHaContext, HassStateChangedEventData, T> mapper)
     {
         return _queuedObservable.Where(n =>
             n.EventType == "state_changed")
             .Select(n => n.ToStateChangedEvent()!)
-            .Select(e => e.MapGeneric(this));
+            .Select(e => mapper(this, e));
     }
 
     public IObservable<Event> Events => _queuedObservable

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -9,6 +9,15 @@ internal static class HassObjectMapper
             Map(source.OldState),
             Map(source.NewState));
     }
+    public static IStateChange MapGeneric(this HassStateChangedEventData source, IHaContext haContext)
+    {
+        return new StateChangeGeneric
+        {
+            Entity = new EntityGeneric(haContext, source.EntityId),
+            RawOld = MapGeneric(source.OldState),
+            RawNew = MapGeneric(source.NewState)
+        };
+    }
 
     public static EntityState? Map(this HassState? hassState)
     {
@@ -18,6 +27,28 @@ internal static class HassObjectMapper
         {
             EntityId = hassState.EntityId,
             State = hassState.State,
+            AttributesJson = hassState.AttributesJson,
+            LastChanged = hassState.LastChanged,
+            LastUpdated = hassState.LastUpdated,
+            Context = hassState.Context == null
+                ? null
+                : new Context
+                {
+                    Id = hassState.Context.Id,
+                    UserId = hassState.Context.UserId,
+                    ParentId = hassState.Context.UserId
+                }
+        };
+    }
+
+    public static IEntityState? MapGeneric(this HassState? hassState)
+    {
+        if (hassState == null) return null;
+
+        return new EntityStateGeneric
+        {
+            EntityId = hassState.EntityId,
+            RawState = hassState.State,
             AttributesJson = hassState.AttributesJson,
             LastChanged = hassState.LastChanged,
             LastUpdated = hassState.LastUpdated,

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -13,7 +13,7 @@ internal static class HassObjectMapper
     {
         return new StateChangeGeneric
         (
-            new EntityGeneric(haContext, source.EntityId),
+            DefaultEntityStateMappers.Base.Entity(haContext, source.EntityId),
             MapGeneric(source.OldState),
             MapGeneric(source.NewState)
         );

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -9,15 +9,6 @@ internal static class HassObjectMapper
             Map(source.OldState),
             Map(source.NewState));
     }
-    public static IStateChange MapGeneric(this HassStateChangedEventData source, IHaContext haContext)
-    {
-        return new StateChangeGeneric
-        (
-            DefaultEntityStateMappers.Base.Entity(haContext, source.EntityId),
-            MapGeneric(source.OldState),
-            MapGeneric(source.NewState)
-        );
-    }
 
     public static EntityState? Map(this HassState? hassState)
     {
@@ -39,28 +30,6 @@ internal static class HassObjectMapper
                     ParentId = hassState.Context.UserId
                 }
         };
-    }
-
-    public static IEntityState? MapGeneric(this HassState? hassState)
-    {
-        if (hassState == null) return null;
-
-        return new EntityStateGeneric
-        (
-            hassState.EntityId,
-            hassState.State,
-            hassState.AttributesJson,
-            hassState.LastChanged,
-            hassState.LastUpdated,
-            hassState.Context == null
-                ? null
-                : new Context
-                {
-                    Id = hassState.Context.Id,
-                    UserId = hassState.Context.UserId,
-                    ParentId = hassState.Context.UserId
-                }
-        );
     }
 
     public static HassTarget? Map(this ServiceTarget? target)

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -12,11 +12,11 @@ internal static class HassObjectMapper
     public static IStateChange MapGeneric(this HassStateChangedEventData source, IHaContext haContext)
     {
         return new StateChangeGeneric
-        {
-            Entity = new EntityGeneric(haContext, source.EntityId),
-            RawOld = MapGeneric(source.OldState),
-            RawNew = MapGeneric(source.NewState)
-        };
+        (
+            new EntityGeneric(haContext, source.EntityId),
+            MapGeneric(source.OldState),
+            MapGeneric(source.NewState)
+        );
     }
 
     public static EntityState? Map(this HassState? hassState)
@@ -46,13 +46,13 @@ internal static class HassObjectMapper
         if (hassState == null) return null;
 
         return new EntityStateGeneric
-        {
-            EntityId = hassState.EntityId,
-            RawState = hassState.State,
-            AttributesJson = hassState.AttributesJson,
-            LastChanged = hassState.LastChanged,
-            LastUpdated = hassState.LastUpdated,
-            Context = hassState.Context == null
+        (
+            hassState.EntityId,
+            hassState.State,
+            hassState.AttributesJson,
+            hassState.LastChanged,
+            hassState.LastUpdated,
+            hassState.Context == null
                 ? null
                 : new Context
                 {
@@ -60,7 +60,7 @@ internal static class HassObjectMapper
                     UserId = hassState.Context.UserId,
                     ParentId = hassState.Context.UserId
                 }
-        };
+        );
     }
 
     public static HassTarget? Map(this ServiceTarget? target)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR proposes a method for enabling full generics flexibility to the entity model. This is done by creating a new family of interfaces that can exist in parallel with the existing classes. This means there is no breaking change required!

The only compromise is that a couple of methods in `IHaContext` need to be duplicated so that the home assistant state can be accessed through a different type. Also, a few of the concrete class names are slightly off from ideal, but the user won't actually interact with them when writing their apps.

I'm submitting this as a draft to get early thoughts on naming and the general structure of the code. As of right now, the code compiles without warnings and passes the first batch of tests that I stole from the tests for the existing Entity code. These tests don't give full coverage, and I will write more and more specific tests. That said, I think the basic stuff will work, but I haven't written any Apps that use it yet.

As a basic guide, the user should NEVER interact directly with any of the concrete classes/records. All interaction is with `IEntity`, `IEntyState`, `IStateChange`, etc. Furthermore, the user will almost exclusively deal with the generic `<TState, TAttributes>` versions of the interfaces, so don't worry too much about all the `Raw*` properties. Users won't be dealing with them.

Here is a partial list of equivalents:
`Entity` is `IEntity<string?, Dictionary<string, object>>`
`Entity<TAttributes>` is `IEntity<string?, TAttributes>`
`NumericEntity` is `IEntity<double?, Dictionary<string, object>>`
`NumericEntity<TAttributes>` is `IEntity<double?, TAttributes>`
The `DateTime` entity type is `IEntity<DateTime?, TAttributes>`

You could make a `IEntity<LockStatus, TAttributes>` that mapped the state to a class that had properties like `IsLocked` etc. I just haven't done it yet, because others need to look at the code first.

One big question is about the default Attributes type. On the existing model, it's `object?`. Here, I just let it be the `Dictionary<string?, object>` type, but that should almost certainly change to something less implementation specific. Honestly, I have a hard time caring about it too much, because I wouldn't ever use it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #715
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs