### PR TITLE
ServiceMetaDataParser `bool? Required` string deserialization

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/NullableBoolJsonConverter.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/NullableBoolJsonConverter.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace NetDaemon.HassModel.CodeGenerator;
+
+internal class NullableBoolJsonConverter : JsonConverter<bool?>
+{
+    public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options) =>
+        writer.WriteBooleanValue(value ?? false);
+
+    public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String => bool.TryParse(reader.GetString(), out var b) ? b : throw new JsonException(),
+            JsonTokenType.Number => reader.TryGetInt64(out long l) ? Convert.ToBoolean(l) : reader.TryGetDouble(out double d) && Convert.ToBoolean(d),
+            _ => throw new JsonException(),
+        };
+}

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/NullableBoolJsonConverter.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/NullableBoolJsonConverter.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace NetDaemon.HassModel.CodeGenerator;
 
+//Based on: https://stackoverflow.com/a/68685773
 internal class NullableBoolJsonConverter : JsonConverter<bool?>
 {
     public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options) =>

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/ServicesMetaData/HassServiceField.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/ServicesMetaData/HassServiceField.cs
@@ -6,6 +6,7 @@ internal record HassServiceField
 {
     public string Field { get; init; } = "";  // cannot be required because the JsonSerializer will complain
     public string? Description { get; init; }
+    [JsonConverter(typeof(NullableBoolJsonConverter))]
     public bool? Required { get; init; }
     public object? Example { get; init; }
     

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServiceMetaDataParserTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServiceMetaDataParserTest.cs
@@ -77,6 +77,41 @@ public class ServiceMetaDataParserTest
       result.First().Services.First().Fields!.First().Selector.Should()
         .BeAssignableTo<EntitySelector>().Which.Domain.Should().BeEquivalentTo("climate", "select");
     }
+    
+    [Fact]
+    public void TestMultiDomainTargetWithRequiredFieldAsString()
+    {
+      var sample = """
+         {
+         "wiser": {
+           "get_schedule": {
+             "name": "Save Schedule to File",
+             "description": "Read the schedule from a room or device and write to an output file in yaml\n",
+             "fields": {
+               "entity_id": {
+                 "name": "Entity",
+                 "description": "A wiser entity",
+                 "required": "true",
+                 "selector": {
+                   "entity": {
+                     "integration": "wiser",
+                     "domain": [
+                       "climate",
+                       "select"
+                       ]
+                     }
+                   }
+                 }
+               }
+             }
+           }
+         }
+         """;
+      var result = Parse(sample);
+      
+      result.First().Services.First().Fields!.First().Selector.Should()
+        .BeAssignableTo<EntitySelector>().Which.Domain.Should().BeEquivalentTo("climate", "select");
+    }
 
     private static IReadOnlyCollection<HassServiceDomain> Parse(string sample)
     {

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServiceMetaDataParserTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServiceMetaDataParserTest.cs
@@ -109,8 +109,7 @@ public class ServiceMetaDataParserTest
          """;
       var result = Parse(sample);
       
-      result.First().Services.First().Fields!.First().Selector.Should()
-        .BeAssignableTo<EntitySelector>().Which.Domain.Should().BeEquivalentTo("climate", "select");
+      result.First().Services.First().Fields!.First().Required.Should().BeTrue();
     }
 
     private static IReadOnlyCollection<HassServiceDomain> Parse(string sample)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Skips invalid sections during deserialization of `HassServiceDomain`, while logging the exceptions and related source JSON data.

Additionally, allowing deserialization of  `bool? Required` in `HassServiceField` from string.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://discord.com/channels/686787269780176998/686796268634374169/1081867058620416022
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs