### PR TITLE
MeansImplicitUse for NetDaemonAppAttribute

### DIFF
--- a/src/AppModel/NetDaemon.AppModel/Common/Attributes/JetBrainsCodeAnnotations.cs
+++ b/src/AppModel/NetDaemon.AppModel/Common/Attributes/JetBrainsCodeAnnotations.cs
@@ -1,0 +1,102 @@
+/* MIT License
+
+Copyright (c) 2016 JetBrains http://www.jetbrains.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. */
+
+#nullable disable
+
+// ReSharper disable UnusedType.Global
+
+#pragma warning disable 1591
+// ReSharper disable UnusedMember.Global
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+// ReSharper disable IntroduceOptionalParameters.Global
+// ReSharper disable MemberCanBeProtected.Global
+// ReSharper disable InconsistentNaming
+// ReSharper disable once CheckNamespace
+namespace JetBrains.Annotations;
+
+/// <summary>
+/// Can be applied to attributes, type parameters, and parameters of a type assignable from <see cref="System.Type"/> .
+/// When applied to an attribute, the decorated attribute behaves the same as <see cref="UsedImplicitlyAttribute"/>.
+/// When applied to a type parameter or to a parameter of type <see cref="System.Type"/>,
+/// indicates that the corresponding type is used implicitly.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.GenericParameter | AttributeTargets.Parameter)]
+internal sealed class MeansImplicitUseAttribute : Attribute
+{
+    public MeansImplicitUseAttribute()
+        : this(ImplicitUseKindFlags.Default, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags)
+        : this(useKindFlags, ImplicitUseTargetFlags.Default) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseTargetFlags targetFlags)
+        : this(ImplicitUseKindFlags.Default, targetFlags) { }
+
+    public MeansImplicitUseAttribute(ImplicitUseKindFlags useKindFlags, ImplicitUseTargetFlags targetFlags)
+    {
+        UseKindFlags = useKindFlags;
+        TargetFlags = targetFlags;
+    }
+
+    public ImplicitUseKindFlags UseKindFlags { get; }
+
+    public ImplicitUseTargetFlags TargetFlags { get; }
+}
+
+/// <summary>
+/// Specifies the details of implicitly used symbol when it is marked
+/// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
+/// </summary>
+[Flags]
+internal enum ImplicitUseKindFlags
+{
+    Default = Access | Assign | InstantiatedWithFixedConstructorSignature,
+    /// <summary>Only entity marked with attribute considered used.</summary>
+    Access = 1,
+    /// <summary>Indicates implicit assignment to a member.</summary>
+    Assign = 2,
+    /// <summary>
+    /// Indicates implicit instantiation of a type with fixed constructor signature.
+    /// That means any unused constructor parameters won't be reported as such.
+    /// </summary>
+    InstantiatedWithFixedConstructorSignature = 4,
+    /// <summary>Indicates implicit instantiation of a type.</summary>
+    InstantiatedNoFixedConstructorSignature = 8,
+}
+
+/// <summary>
+/// Specifies what is considered to be used implicitly when marked
+/// with <see cref="MeansImplicitUseAttribute"/> or <see cref="UsedImplicitlyAttribute"/>.
+/// </summary>
+[Flags]
+internal enum ImplicitUseTargetFlags
+{
+    Default = Itself,
+    Itself = 1,
+    /// <summary>Members of the type marked with the attribute are considered used.</summary>
+    Members = 2,
+    /// <summary> Inherited entities are considered used. </summary>
+    WithInheritors = 4,
+    /// <summary>Entity marked with the attribute and all its members considered used.</summary>
+    WithMembers = Itself | Members
+}

--- a/src/AppModel/NetDaemon.AppModel/Common/Attributes/NetDaemonAppAttribute.cs
+++ b/src/AppModel/NetDaemon.AppModel/Common/Attributes/NetDaemonAppAttribute.cs
@@ -1,8 +1,11 @@
+using JetBrains.Annotations;
+
 namespace NetDaemon.AppModel;
 
 /// <summary>
 ///     Marks a class as a NetDaemonApp
 /// </summary>
+[MeansImplicitUse]
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class NetDaemonAppAttribute : Attribute
 {

--- a/src/AppModel/NetDaemon.AppModel/NetDaemon.AppModel.csproj
+++ b/src/AppModel/NetDaemon.AppModel/NetDaemon.AppModel.csproj
@@ -20,7 +20,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />

--- a/src/AppModel/NetDaemon.AppModel/NetDaemon.AppModel.csproj
+++ b/src/AppModel/NetDaemon.AppModel/NetDaemon.AppModel.csproj
@@ -20,6 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the JetBrains MeansImplicitUse to the NetDaemonAppAttribute.
Helps R# and Rider to mark classes as used if the NetDeamonAppAttribute is used

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs