### PR TITLE
Guide users to use WhenStateIsFor with a IScheduler instance.

### DIFF
--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -37,17 +37,22 @@ public static class StateObservableExtensions
         Func<EntityState?, bool> predicate,
         TimeSpan timeSpan,
         IScheduler scheduler)
-    
-        => observable
+    {
+        if (observable == null) throw new ArgumentNullException(nameof(observable));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+        if (scheduler == null) throw new ArgumentNullException(nameof(scheduler));
+        
+        return observable
             // Only process changes that start or stop matching the predicate
             .Where(e => predicate(e.Old) != predicate(e.New))
-                
+
             // Both  will restart the timer
             .Throttle(timeSpan, scheduler)
-            
+
             // But only when the new state matches the predicate we emit it
             .Where(e => predicate(e.New));
-    
+    }
+
     /// <summary>
     /// Waits for an EntityState to match a predicate for the specified time
     /// </summary>
@@ -57,10 +62,15 @@ public static class StateObservableExtensions
         TimeSpan timeSpan,
         IScheduler scheduler)
         where TEntity : Entity
-        where TEntityState : EntityState 
-
-        => observable
+        where TEntityState : EntityState
+    {
+        if (observable == null) throw new ArgumentNullException(nameof(observable));
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+        if (scheduler == null) throw new ArgumentNullException(nameof(scheduler));
+        
+        return observable
             .Where(e => predicate(e.Old) != predicate(e.New))
             .Throttle(timeSpan, scheduler)
             .Where(e => predicate(e.New));
+    }
 }

--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -10,18 +10,40 @@ public static class StateObservableExtensions
     /// <summary>
     /// Waits for an EntityState to match a predicate for the specified time
     /// </summary>
+    [Obsolete("Use the overload with IScheduler instead")]
+    public static IObservable<StateChange> WhenStateIsFor(
+        this IObservable<StateChange> observable, 
+        Func<EntityState?, bool> predicate,
+        TimeSpan timeSpan)
+        => observable.WhenStateIsFor(predicate, timeSpan, Scheduler.Default);
+
+    /// <summary>
+    /// Waits for an EntityState to match a predicate for the specified time
+    /// </summary>
+    [Obsolete("Use the overload with IScheduler instead")]
+    public static IObservable<StateChange<TEntity, TEntityState>> WhenStateIsFor<TEntity, TEntityState>(
+        this IObservable<StateChange<TEntity, TEntityState>> observable, 
+        Func<TEntityState?, bool> predicate, 
+        TimeSpan timeSpan)
+        where TEntity : Entity
+        where TEntityState : EntityState 
+        => observable.WhenStateIsFor(predicate, timeSpan, Scheduler.Default);
+    
+    /// <summary>
+    /// Waits for an EntityState to match a predicate for the specified time
+    /// </summary>
     public static IObservable<StateChange> WhenStateIsFor(
         this IObservable<StateChange> observable, 
         Func<EntityState?, bool> predicate,
         TimeSpan timeSpan,
-        IScheduler? scheduler = null)
+        IScheduler scheduler)
     
         => observable
             // Only process changes that start or stop matching the predicate
             .Where(e => predicate(e.Old) != predicate(e.New))
                 
             // Both  will restart the timer
-            .Throttle(timeSpan, scheduler ?? Scheduler.Default)
+            .Throttle(timeSpan, scheduler)
             
             // But only when the new state matches the predicate we emit it
             .Where(e => predicate(e.New));
@@ -33,12 +55,12 @@ public static class StateObservableExtensions
         this IObservable<StateChange<TEntity, TEntityState>> observable, 
         Func<TEntityState?, bool> predicate, 
         TimeSpan timeSpan,
-        IScheduler? scheduler = null)
+        IScheduler scheduler)
         where TEntity : Entity
         where TEntityState : EntityState 
 
         => observable
             .Where(e => predicate(e.Old) != predicate(e.New))
-            .Throttle(timeSpan, scheduler ?? Scheduler.Default)
+            .Throttle(timeSpan, scheduler)
             .Where(e => predicate(e.New));
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a Source compatible change that will guide users to provide a ISchedule instance to WhenStateIsFor. This is however a binary breaking change but I think that might be fine as users will recompile anyway after updating netdaemon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #801 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs