### PR TITLE
Refactor event subscription

### DIFF
--- a/src/Client/NetDaemon.HassClient.Debug/Service.cs
+++ b/src/Client/NetDaemon.HassClient.Debug/Service.cs
@@ -48,13 +48,12 @@ internal class DebugService : BackgroundService
         _hostLifetime.StopApplication();
     }
 
-    private Task OnHomeAssistantClientConnected(IHomeAssistantConnection connection)
+    private async Task OnHomeAssistantClientConnected(IHomeAssistantConnection connection)
     {
         _logger.LogInformation("HassClient connected and processing events");
-        connection.OnHomeAssistantEvent.Subscribe(HandleEvent);
-
-        // Add your code to test here
-        return Task.CompletedTask;
+        var hassEvents = await connection.SubscribeToHomeAssistantEventsAsync(null, _cancelToken ?? CancellationToken.None).ConfigureAwait(false);
+        hassEvents.Subscribe(HandleEvent);
+      
     }
 
     private void OnHomeAssistantClientDisconnected(DisconnectReason reason)

--- a/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/ServiceCollectionExtensionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/ExtensionsTest/ServiceCollectionExtensionTests.cs
@@ -19,6 +19,5 @@ public class ServiceCollectionExtensionTests
         apiManager.Should().NotBeNull();
 
         Assert.Null(connection);
-        Assert.Throws<NullReferenceException>(() => serviceProvider.GetService<IObservable<HassEvent>>());
     }
 }

--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantRunnerTest/HomeAssistantClientMock.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantRunnerTest/HomeAssistantClientMock.cs
@@ -23,7 +23,7 @@ internal class HomeAssistantClientMock : Mock<IHomeAssistantClient>
                 Task.FromResult(_haConnectionMock.Object));
 
         _haConnectionMock.Setup(n =>
-            n.ProcessHomeAssistantEventsAsync(It.IsAny<CancellationToken>())
+            n.WaitForConnectionToCloseAsync(It.IsAny<CancellationToken>())
         ).Returns(
             async (CancellationToken cancelToken) =>
             {

--- a/src/Client/NetDaemon.HassClient/Common/Extensions/ServiceCollectionExtension.cs
+++ b/src/Client/NetDaemon.HassClient/Common/Extensions/ServiceCollectionExtension.cs
@@ -18,7 +18,6 @@ public static class ServiceCollectionExtensions
             .AddSingleton<HomeAssistantApiManager>()
             .AddSingleton<IHomeAssistantApiManager>(s => s.GetRequiredService<HomeAssistantApiManager>())
             .AddTransient(s => s.GetRequiredService<IHomeAssistantRunner>().CurrentConnection!)
-            .AddTransient(s => s.GetRequiredService<IHomeAssistantRunner>().CurrentConnection!.OnHomeAssistantEvent)
             .AddWebSocketFactory()
             .AddPipelineFactory()
             .AddConnectionFactory()

--- a/src/Client/NetDaemon.HassClient/Common/IHomeAssistantConnection.cs
+++ b/src/Client/NetDaemon.HassClient/Common/IHomeAssistantConnection.cs
@@ -3,13 +3,18 @@ namespace NetDaemon.Client;
 public interface IHomeAssistantConnection : IHomeAssistantApiManager, IAsyncDisposable
 {
     /// <summary>
-    ///     Allows subscription on all events
+    ///     Subscribe to all events and return a IObservable getting the events
     /// </summary>
-    /// <remark>
-    ///     This requires that "ProcessHomeAssistantEvents" task is running
-    /// </remark>
-    IObservable<HassEvent> OnHomeAssistantEvent { get; }
-
+    /// <param name="eventType">The type of event to subscribe to, null if all events. If users want non optimized separate subscriptions on all events, provide a "*" as input.</param>
+    /// <param name="cancelToken">token to cancel operation</param>
+    /// <summary>
+    ///     If eventType is null or empty the HomeAssistant connection optimizes and use same
+    ///     observable for all subscriptions on all events.
+    ///     Users can still provide a "*" as input for eventType and have separated subscriptions
+    ///     for all events.
+    /// </summary>
+    Task<IObservable<HassEvent>> SubscribeToHomeAssistantEventsAsync(string? eventType, CancellationToken cancelToken);
+    
     /// <summary>
     ///     Sends a command message to Home Assistant without handling the result
     /// </summary>
@@ -41,10 +46,10 @@ public interface IHomeAssistantConnection : IHomeAssistantApiManager, IAsyncDisp
         where T : CommandMessage;
     
     /// <summary>
-    ///     Start processing Home Assistant events
+    ///     Return if connection to HomeAssistant is closed for any reason
     /// </summary>
     /// <param name="cancelToken">The token to cancel the processing of events</param>
-    Task ProcessHomeAssistantEventsAsync(CancellationToken cancelToken);
+    Task WaitForConnectionToCloseAsync(CancellationToken cancelToken);
 }
 
 /// <summary>

--- a/src/Client/NetDaemon.HassClient/Internal/Helpers/AsyncLazy.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Helpers/AsyncLazy.cs
@@ -1,0 +1,9 @@
+﻿namespace NetDaemon.Client.Internal.Helpers;
+
+public class AsyncLazy<T> : Lazy<Task<T>>
+{
+    public AsyncLazy(Func<Task<T>> taskFactory) :
+        base(() => Task.Factory.StartNew(taskFactory).Unwrap())
+    {
+    }
+}

--- a/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
@@ -15,13 +15,12 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
 
     private const int WaitForResultTimeout = 20000;
 
-    private int _eventSubscribtionMessageId = -1;
-
-    private readonly SemaphoreSlim _messageIdSemaphore = new(1,1);
+    private readonly SemaphoreSlim _messageIdSemaphore = new(1, 1);
     private int _messageId = 1;
+    private readonly AsyncLazy<IObservable<HassEvent>> _lazyAllEventsObservable;
 
     #endregion
-
+    
     /// <summary>
     ///     Default constructor
     /// </summary>
@@ -39,8 +38,13 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
         _apiManager = apiManager;
         _logger = logger;
 
-        _resultMessageHandler = new(_logger);
+        _resultMessageHandler = new ResultMessageHandler(_logger);
 
+        // We lazily cache same observable for all events. There are no reason we should use multiple subscriptions
+        // to all events. If people wants that they can provide a "*" type and get the same thing
+        _lazyAllEventsObservable = new AsyncLazy<IObservable<HassEvent>>(async Task<IObservable<HassEvent>>() =>
+            await SubscribeToHomeAssistantEventsInternalAsync(null, _internalCancelSource.Token));
+            
         if (_transportPipeline.WebSocketState != WebSocketState.Open)
             throw new ApplicationException(
                 $"Expected WebSocket state 'Open' got '{_transportPipeline.WebSocketState}'");
@@ -49,47 +53,43 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
             TaskCreationOptions.LongRunning);
     }
 
-    public IObservable<HassEvent> OnHomeAssistantEvent =>
-        _hassMessageSubject.Where(n => n.Type == "event" && n.Id == _eventSubscribtionMessageId).Select(n => n.Event!);
+    public async Task<IObservable<HassEvent>> SubscribeToHomeAssistantEventsAsync(string? eventType,
+        CancellationToken cancelToken)
+    {
+        // When subscribe all events, optimize using the same IObservable<HassEvent> if we subscribe multiple times
+        if (string.IsNullOrEmpty(eventType))
+            return await _lazyAllEventsObservable.Value;
 
-    public async Task ProcessHomeAssistantEventsAsync(CancellationToken cancelToken)
+        return await SubscribeToHomeAssistantEventsInternalAsync(eventType, cancelToken);
+    }
+
+    private async Task<IObservable<HassEvent>> SubscribeToHomeAssistantEventsInternalAsync(string? eventType,
+        CancellationToken cancelToken)
     {
         var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
             cancelToken,
             _internalCancelSource.Token
         );
-        // Start by subscribing to all events
-        await SubscribeToAllHomeAssistantEvents(combinedTokenSource.Token).ConfigureAwait(false);
-        await combinedTokenSource.Token.AsTask().ConfigureAwait(false);
+
+        var result = await SendCommandAndReturnHassMessageResponseAsync(new SubscribeEventCommand(),
+            combinedTokenSource.Token).ConfigureAwait(false);
+
+        // The id if the message we used to subscribe should be used as the filter for the event messages
+        var observableResult = _hassMessageSubject.Where(n => n.Type == "event" && n.Id == result?.Id)
+            .Select(n => n.Event!);
+        
+        return observableResult;
     }
-
-    private async Task<Task<HassMessage>> SendCommandAsyncInternal<T>(T command, CancellationToken cancelToken) where T : CommandMessage
+    
+    public async Task WaitForConnectionToCloseAsync(CancellationToken cancelToken)
     {
-        // The semaphore can fail to be taken in rare cases so we need
-        // to keep this out of the try/finally block so it will not be released
-        await _messageIdSemaphore.WaitAsync(cancelToken).ConfigureAwait(false);
-        try
-        {
-            // We need to make sure messages to HA are send with increasing Ids therefore we need to synchronize
-            // increasing the messageId and Sending the message
-            command.Id = ++_messageId;
+        var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancelToken,
+            _internalCancelSource.Token
+        );
 
-            // We make a task that subscribe for the return result message
-            // this task will be returned and handled by caller
-            var resultEvent = _hassMessageSubject
-                .Where(n => n.Type == "result" && n.Id == command.Id)
-                .FirstAsync().ToTask(CancellationToken.None);
-            // We dont want to pass the incoming CancellationToken here because it will throw a TaskCanceledException
-            // when calling services from an Apps Dispose(Async) and hide possible actual exceptions
-
-            await _transportPipeline.SendMessageAsync(command, cancelToken);
-
-            return resultEvent;
-        }
-        finally
-        {
-            _messageIdSemaphore.Release();
-        }
+        // Just wait for token source (internal och provided one)
+        await combinedTokenSource.Token.AsTask().ConfigureAwait(false);
     }
 
     public async Task SendCommandAsync<T>(T command, CancellationToken cancelToken) where T : CommandMessage
@@ -115,8 +115,9 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
         // The SendCommmandsAndReturnHAssMessageResponse will throw if not successful so just ignore errors here
         return hassMessage?.ResultElement;
     }
-    
-    public async Task<HassMessage?> SendCommandAndReturnHassMessageResponseAsync<T>(T command, CancellationToken cancelToken)
+
+    public async Task<HassMessage?> SendCommandAndReturnHassMessageResponseAsync<T>(T command,
+        CancellationToken cancelToken)
         where T : CommandMessage
     {
         var resultMessageTask = await SendCommandAsyncInternal(command, cancelToken);
@@ -124,16 +125,16 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
         var awaitedTask = await Task.WhenAny(resultMessageTask, Task.Delay(WaitForResultTimeout, cancelToken));
 
         if (awaitedTask != resultMessageTask)
-        {
             // We have a timeout
-            throw new InvalidOperationException($"Send command ({command.Type}) did not get response in timely fashion. Sent command is {command.ToJsonElement()}");
-        }
+            throw new InvalidOperationException(
+                $"Send command ({command.Type}) did not get response in timely fashion. Sent command is {command.ToJsonElement()}");
 
         if (resultMessageTask.Result.Success ?? false)
             return resultMessageTask.Result;
 
         // Non successful command should throw exception
-        throw new InvalidOperationException($"Failed command ({command.Type}) error: {resultMessageTask.Result.Error}.  Sent command is {command.ToJsonElement()}");
+        throw new InvalidOperationException(
+            $"Failed command ({command.Type}) error: {resultMessageTask.Result.Error}.  Sent command is {command.ToJsonElement()}");
     }
 
     public async ValueTask DisposeAsync()
@@ -172,15 +173,35 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
 
     public IObservable<HassMessage> OnHassMessage => _hassMessageSubject;
 
-    private async Task SubscribeToAllHomeAssistantEvents(CancellationToken cancelToken)
+    private async Task<Task<HassMessage>> SendCommandAsyncInternal<T>(T command, CancellationToken cancelToken) where T : CommandMessage
     {
-        var result = await SendCommandAndReturnHassMessageResponseAsync(new SubscribeEventCommand(),
-            cancelToken).ConfigureAwait(false);
-        
-        // The id if the message we used to subscribe should be used as the filter for the event messages 
-        _eventSubscribtionMessageId = result?.Id ?? -1;
-    }
+        // The semaphore can fail to be taken in rare cases so we need
+        // to keep this out of the try/finally block so it will not be released
+        await _messageIdSemaphore.WaitAsync(cancelToken).ConfigureAwait(false);
+        try
+        {
+            // We need to make sure messages to HA are send with increasing Ids therefore we need to synchronize
+            // increasing the messageId and Sending the message
+            command.Id = ++_messageId;
 
+            // We make a task that subscribe for the return result message
+            // this task will be returned and handled by caller
+            var resultEvent = _hassMessageSubject
+                .Where(n => n.Type == "result" && n.Id == command.Id)
+                .FirstAsync().ToTask(CancellationToken.None);
+            // We dont want to pass the incoming CancellationToken here because it will throw a TaskCanceledException
+            // when calling services from an Apps Dispose(Async) and hide possible actual exceptions
+
+            await _transportPipeline.SendMessageAsync(command, cancelToken);
+
+            return resultEvent;
+        }
+        finally
+        {
+            _messageIdSemaphore.Release();
+        }
+    }
+    
     private async Task HandleNewMessages()
     {
         try

--- a/src/Client/NetDaemon.HassClient/Internal/HomeAssistantRunner.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/HomeAssistantRunner.cs
@@ -84,7 +84,7 @@ internal class HomeAssistantRunner : IHomeAssistantRunner
                 CurrentConnection = await _client.ConnectAsync(host, port, ssl, token, websocketPath, combinedToken.Token)
                     .ConfigureAwait(false);
                 // Start the event processing before publish the connection
-                var eventsTask = CurrentConnection.ProcessHomeAssistantEventsAsync(combinedToken.Token);
+                var eventsTask = CurrentConnection.WaitForConnectionToCloseAsync(combinedToken.Token);
                 _onConnectSubject.OnNext(CurrentConnection);
                 await eventsTask.ConfigureAwait(false);
             }

--- a/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
@@ -177,7 +177,7 @@ public class AppScopedHaContextProviderTest
 
         backgroundTrackerMock.Verify(n => n.TrackBackgroundTask(It.IsAny<Task?>(), It.IsAny<string>()), Times.Once);
     }
-
+    
     [Fact]
     public async Task TestThatSendEventTrackBackgroundTask()
     {
@@ -206,6 +206,10 @@ public class AppScopedHaContextProviderTest
 
 
         serviceCollection.AddSingleton(_hassConnectionMock.Object);
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_hassEventSubjectMock
+            );
         serviceCollection.AddSingleton<IObservable<HassEvent>>(_hassEventSubjectMock);
 
         var haRunnerMock = new Mock<IHomeAssistantRunner>();

--- a/src/HassModel/NetDaemon.HassModel.Tests/Internal/EntityAreaCachTests.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Internal/EntityAreaCachTests.cs
@@ -21,6 +21,10 @@ public class EntityAreaCachTests
 
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(_hassConnectionMock.Object);
 
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testSubject);
+        
         _hassConnectionMock.Setup(
             m => m.SendCommandAndReturnResponseAsync<SimpleCommand, IReadOnlyCollection<HassDevice>>(
                 It.IsAny<SimpleCommand>(), It.IsAny<CancellationToken>()
@@ -69,7 +73,10 @@ public class EntityAreaCachTests
 
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(_hassConnectionMock.Object);
 
-
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testSubject);
+        
         _hassConnectionMock.Setup(
             m => m.SendCommandAndReturnResponseAsync<SimpleCommand, IReadOnlyCollection<HassDevice>>(
                 It.IsAny<SimpleCommand>(), It.IsAny<CancellationToken>()
@@ -123,6 +130,10 @@ public class EntityAreaCachTests
 
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(_hassConnectionMock.Object);
 
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testSubject);
+        
         _hassConnectionMock.Setup(
             m => m.SendCommandAndReturnResponseAsync<SimpleCommand, IReadOnlyCollection<HassDevice>>(
                 It.IsAny<SimpleCommand>(), It.IsAny<CancellationToken>()
@@ -181,6 +192,10 @@ public class EntityAreaCachTests
                 It.IsAny<SimpleCommand>(), It.IsAny<CancellationToken>()
             )).ReturnsAsync(Array.Empty<HassDevice>());
 
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(testSubject);
+        
         _hassConnectionMock.Setup(
                 m => m.SendCommandAndReturnResponseAsync<SimpleCommand, IReadOnlyCollection<HassArea>>
                 (

--- a/src/HassModel/NetDaemon.HassModel.Tests/Internal/EntityStateCacheTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Internal/EntityStateCacheTest.cs
@@ -34,6 +34,11 @@ public class EntityStateCacheTest
                 new() {EntityId = entityId, State = "InitialState"}
             });
 
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testSubject
+            );
+        
         var serviceColletion = new ServiceCollection();
         _ = serviceColletion.AddTransient<IObservable<HassEvent>>(_ => testSubject);
         var sp = serviceColletion.BuildServiceProvider();
@@ -100,7 +105,12 @@ public class EntityStateCacheTest
             });
 
         var serviceColletion = new ServiceCollection();
-        _ = serviceColletion.AddTransient<IObservable<HassEvent>>(_ => testSubject);
+        
+        _hassConnectionMock.Setup(n =>
+                n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testSubject
+            );
+        
         var sp = serviceColletion.BuildServiceProvider();
 
         using var cache = new EntityStateCache(haRunnerMock.Object, sp);

--- a/src/HassModel/NetDeamon.HassModel/Internal/EntityAreaCache.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/EntityAreaCache.cs
@@ -27,7 +27,7 @@ internal class EntityAreaCache : IDisposable
     {
         _cancellationToken = cancellationToken;
 
-        var events = _provider.GetRequiredService<IObservable<HassEvent>>();
+        var events = await _hassRunner.CurrentConnection!.SubscribeToHomeAssistantEventsAsync(null, _cancellationToken).ConfigureAwait(false);
         _eventSubscription = events.Subscribe(HandleEvent);
 
         await LoadAreas().ConfigureAwait(false);

--- a/src/HassModel/NetDeamon.HassModel/Internal/EntityStateCache.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/EntityStateCache.cs
@@ -37,7 +37,7 @@ internal class EntityStateCache : IDisposable
     {
         _ = _hassRunner.CurrentConnection ?? throw new InvalidOperationException();
 
-        var events = _provider.GetRequiredService<IObservable<HassEvent>>();
+        var events = await _hassRunner.CurrentConnection!.SubscribeToHomeAssistantEventsAsync(null,  cancellationToken).ConfigureAwait(false);
         _eventSubscription = events.Subscribe(HandleEvent);
 
         var hassStates = await _hassRunner.CurrentConnection.GetStatesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Runtime/NetDaemon.Runtime.Tests/Helpers/HomeAssistantRunnerMock.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Helpers/HomeAssistantRunnerMock.cs
@@ -59,7 +59,7 @@ internal class HomeAssistantClientMock : Mock<IHomeAssistantClient>
         );
 
         ConnectionMock.Setup(n =>
-            n.ProcessHomeAssistantEventsAsync(It.IsAny<CancellationToken>())
+            n.WaitForConnectionToCloseAsync(It.IsAny<CancellationToken>())
         ).Returns(
             async (CancellationToken cancelToken) =>
             {
@@ -76,7 +76,8 @@ internal class HomeAssistantConnectionMock : Mock<IHomeAssistantConnection>
     public HomeAssistantConnectionMock()
     {
         HomeAssistantEventMock = new();
-        SetupGet(n => n.OnHomeAssistantEvent).Returns(HomeAssistantEventMock);
+        Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(HomeAssistantEventMock);
     }
 
     internal void AddStateChangeEvent(HassState oldState, HassState newState)

--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
@@ -236,7 +236,8 @@ public class AppStateManagerTests
         var homeAssistantStateUpdater =
             scopedProvider.ServiceProvider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
         Subject<HassEvent> hassEvent = new();
-        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
+        haConnectionMock.Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hassEvent);
 
         // ACT
         await homeAssistantStateUpdater.InitializeAsync(haConnectionMock.Object, appModelContextMock.Object)
@@ -256,8 +257,11 @@ public class AppStateManagerTests
         appModelContextMock.SetupGet(n => n.Applications)
             .Returns(new List<IApplication>(){new Mock<IApplication>().Object});
         var haConnectionMock = new Mock<IHomeAssistantConnection>();
-        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(new Subject<HassEvent>());
+        
+        haConnectionMock.Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Subject<HassEvent>());
         var haRunnerMock = new Mock<IHomeAssistantRunner>();
+        
         haRunnerMock.SetupGet(n => n.CurrentConnection).Returns(haConnectionMock.Object);
 
         var environmentMock = new Mock<IHostEnvironment>();
@@ -296,8 +300,12 @@ public class AppStateManagerTests
         var homeAssistantStateUpdater =
             provider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
         Subject<HassEvent> hassEvent = new();
-        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
+        
+        haConnectionMock.Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hassEvent);
+        
         appMock.SetupGet(n => n.Id).Returns("app");
+        
         appModelContextMock.SetupGet(n => n.Applications).Returns(
             new List<IApplication>
             {
@@ -346,8 +354,12 @@ public class AppStateManagerTests
 
         var appMock = new Mock<IApplication>();
 
-        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
+        
+        haConnectionMock.Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hassEvent);
+        
         appMock.SetupGet(n => n.Id).Returns("app");
+        
         appModelContextMock.SetupGet(n => n.Applications).Returns(
             new List<IApplication>
             {
@@ -398,9 +410,14 @@ public class AppStateManagerTests
 
         var homeAssistantStateUpdater =
             provider.GetRequiredService<IHandleHomeAssistantAppStateUpdates>();
+        
         Subject<HassEvent> hassEvent = new();
-        haConnectionMock.SetupGet(n => n.OnHomeAssistantEvent).Returns(hassEvent);
+        
+        haConnectionMock.Setup(n => n.SubscribeToHomeAssistantEventsAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(hassEvent);
+        
         appMock.SetupGet(n => n.Id).Returns("app");
+        
         appModelContextMock.SetupGet(n => n.Applications).Returns(
             new List<IApplication>
             {

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
@@ -27,7 +27,10 @@ internal class AppStateManager : IAppStateManager, IHandleHomeAssistantAppStateU
             await _appStateRepository.RemoveNotUsedStatesAsync(appContext.Applications.Select(a => a.Id).ToList()!,
                 _cancelTokenSource.Token);
 
-        haConnection.OnHomeAssistantEvent
+        var hassEvents = await haConnection.SubscribeToHomeAssistantEventsAsync(null, _cancelTokenSource.Token)
+            .ConfigureAwait(false);
+        
+        hassEvents
             .Where(n => n.EventType == "state_changed")
             .Select(async s =>
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This PR introduces some breaking changes. The rationale for these changes is to allow more granular subscriptions to events and remove default subscriptions to all events for users of `IHomeAssistantConnection`.  

Most users does not use the `HassClient` and should not be affected by this change.

### IHomeAssistantConnection
- `ProcessHomeAssistantEventsAsync` method no longer defaults to subscribing to all event changes. That logic is moved the new method `SubscribeToHomeAssistantEventsAsync` that returns the `IObservable<HassEvent>` instead of make it available as a property on the interface itself. 
- `OnHomeAssistantEvent` is removed and replaced by the method `SubscribeToHomeAssistantEventsAsync`
### ServiceCollectionExtensions
- `IObservable<HassEvent>` is no longer injectable through DI due to internal design change providing it through the `SubscribeToHomeAssistantEventsAsync` on the `IHomeAsstantConnection` interface instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR refactors how event subscriptions work. Now it does not automatically subscribe to all events from the HomeAssistantConnection. The runtime and HassModel do add these subscriptions automatically. The function now also supports subscribing to specific avents.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs