### PR TITLE
Add default metadata for lights entities

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
@@ -1,0 +1,95 @@
+{
+  "domains": [
+    {
+      "domain": "light",
+      "entities": [],
+      "attributes": [
+        {
+          "jsonName": "supported_color_modes",
+          "cSharpName": "SupportedColorModes",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },
+        {
+          "jsonName": "supported_features",
+          "cSharpName": "SupportedFeatures",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "color_mode",
+          "cSharpName": "ColorMode",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "min_color_temp_kelvin",
+          "cSharpName": "MinColorTempKelvin",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "max_color_temp_kelvin",
+          "cSharpName": "MaxColorTempKelvin",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "min_mireds",
+          "cSharpName": "MinMireds",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "max_mireds",
+          "cSharpName": "MaxMireds",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "brightness",
+          "cSharpName": "Brightness",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "color_temp_kelvin",
+          "cSharpName": "ColorTempKelvin",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "color_temp",
+          "cSharpName": "ColorTemp",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "hs_color",
+          "cSharpName": "HsColor",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.Double]"
+        },
+        {
+          "jsonName": "rgb_color",
+          "cSharpName": "RgbColor",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.Double]"
+        },
+        {
+          "jsonName": "xy_color",
+          "cSharpName": "XyColor",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.Double]"
+        },
+        {
+          "jsonName": "entity_id",
+          "cSharpName": "EntityId",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },        
+        {
+          "jsonName": "some_new_attribute",
+          "cSharpName": "SomeNewAttribute",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },
+        {
+          "jsonName": "effect_list",
+          "cSharpName": "EffectList",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },
+        {
+          "jsonName": "color",
+          "cSharpName": "Color",
+          "clrType": "System.Object"
+        }
+      ]
+    }
+  ]
+}

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
@@ -75,11 +75,6 @@
           "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
         },        
         {
-          "jsonName": "some_new_attribute",
-          "cSharpName": "SomeNewAttribute",
-          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
-        },
-        {
           "jsonName": "effect_list",
           "cSharpName": "EffectList",
           "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/EntityMetaDataMerger.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/EntityMetaDataMerger.cs
@@ -43,6 +43,7 @@ internal static class EntityMetaDataMerger
     {
         if (codeGenerationSettings.UseAttributeBaseClasses)
         {
+            WriteWarningMessageToConsole("Usage of attribute classes is deprecated and will be removed in future release. We now include default metadata that gives same behaviour.");
             previous = SetBaseTypes(previous);
             current = SetBaseTypes(current);
         }
@@ -53,6 +54,13 @@ internal static class EntityMetaDataMerger
                 .Select(HandleDuplicateCSharpNames)
                 .ToList()
         };
+    }
+
+    private static void WriteWarningMessageToConsole(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine(message);
+        Console.ResetColor();
     }
 
     public static EntitiesMetaData SetBaseTypes(EntitiesMetaData entitiesMetaData)

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
@@ -50,18 +50,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
       <EmbeddedResource Include="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Content Include="bin\Debug\net7.0\ServicesMetaData.json" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="bin\Debug\net7.0\" />
-      <Folder Include="bin\Release\net7.0\" />
-    </ItemGroup>
     <PropertyGroup>
         <CodeAnalysisRuleSet>..\..\..\.linting\roslynator.ruleset</CodeAnalysisRuleSet>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
@@ -51,8 +51,6 @@
 
     <ItemGroup>
       <None Remove="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
-      <Resource Include="bin\Debug\net7.0\DefaultEntityMetaData.json" />
-      <Resource Include="bin\Debug\net7.0\EntityMetaData.json" />
       <EmbeddedResource Include="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
     </ItemGroup>
 

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
@@ -48,6 +48,22 @@
     <ItemGroup>
         <ProjectReference Include="..\NetDeamon.HassModel\NetDaemon.HassModel.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
+      <Resource Include="bin\Debug\net7.0\DefaultEntityMetaData.json" />
+      <Resource Include="bin\Debug\net7.0\EntityMetaData.json" />
+      <EmbeddedResource Include="MetaData\DefaultMetadata\DefaultEntityMetaData.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="bin\Debug\net7.0\ServicesMetaData.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="bin\Debug\net7.0\" />
+      <Folder Include="bin\Release\net7.0\" />
+    </ItemGroup>
     <PropertyGroup>
         <CodeAnalysisRuleSet>..\..\..\.linting\roslynator.ruleset</CodeAnalysisRuleSet>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
@@ -1,0 +1,21 @@
+﻿using NetDaemon.Client.Settings;
+using NetDaemon.HassModel.CodeGenerator;
+
+namespace NetDaemon.HassModel.Tests.CodeGenerator;
+
+public class ControllerTest
+{
+    [Fact]
+    public async Task ControllerShouldReturnDefaultValueForMetadata()
+    {
+        // ARRANGE
+        var controller = new Controller(new CodeGenerationSettings(), new HomeAssistantSettings());
+
+        // ACT
+        var result = await controller.LoadEntitiesMetaDataAsync();
+
+        // ASSERT
+        result.Domains.Count.Should().Be(1);
+        result.Domains.Single(x => x.Domain == "light").Should().NotBeNull();
+    }
+}

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
@@ -17,5 +17,6 @@ public class ControllerTest
         // ASSERT
         result.Domains.Count.Should().Be(1);
         result.Domains.Single(x => x.Domain == "light").Should().NotBeNull();
+        result.Domains.Single(x => x.Domain == "light").Attributes.SingleOrDefault(x => x.JsonName == "brightness").Should().NotBeNull();
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR includes default metadata for light domain so we can get default values for attributes like `Brightness` even if the lights are off when generating the first time. This PR also deprecates the usage of `UseAttributeBaseClasses` setting since this chage makes it obsolete and much easier to include additional default metadata for other domains in the future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs