### PR TITLE
Add media player to default meta

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
@@ -1,8 +1,10 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using NetDaemon.HassModel.Entities.Core;
 
 namespace NetDaemon.HassModel.CodeGenerator.Helpers;
 
+[SuppressMessage("", "CS0618")]
 internal static class NamingHelper
 {
     public const string EntitiesClassName =  "Entities";
@@ -58,7 +60,7 @@ internal static class NamingHelper
         // Use short name if the type is in one of the using namespaces
         return UsingNamespaces.Any(u => type.Namespace == u) ? type.Name : type.FullName!;
     }
-
+    
     public static readonly string[] UsingNamespaces =
     {
         "System",
@@ -67,7 +69,10 @@ internal static class NamingHelper
         typeof(JsonPropertyNameAttribute).Namespace!,
         typeof(IHaContext).Namespace!,
         typeof(Entity).Namespace!,
+        // Have to suppress warning because of obsolete LightAttributesBase. Suppress message attribute did not work.  
+#pragma warning disable CS0618 // Type or member is obsolete
         typeof(LightAttributesBase).Namespace!
+#pragma warning restore CS0618 // Type or member is obsolete
     };
 
     private static string GetVariableName(string typeName, string variablePrefix)

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/DefaultMetadata/DefaultEntityMetaData.json
@@ -85,6 +85,157 @@
           "clrType": "System.Object"
         }
       ]
+    },
+    {
+      "domain": "media_player",
+      "entities": [],
+      "attributes": [
+        {
+          "jsonName": "app_id",
+          "cSharpName": "AppId",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "app_name",
+          "cSharpName": "AppName",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "device_class",
+          "cSharpName": "DeviceClass",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "entity_picture_local",
+          "cSharpName": "EntityPictureLocal",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "entity_picture",
+          "cSharpName": "EntityPicture",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "icon",
+          "cSharpName": "Icon",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "friendly_name",
+          "cSharpName": "FriendlyName",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "supported_features",
+          "cSharpName": "SupportedFeatures",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "volume_level",
+          "cSharpName": "VolumeLevel",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "is_volume_muted",
+          "cSharpName": "IsVolumeMuted",
+          "clrType": "System.Boolean"
+        },
+        {
+          "jsonName": "media_content_id",
+          "cSharpName": "MediaContentId",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "media_content_type",
+          "cSharpName": "MediaContentType",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "media_duration",
+          "cSharpName": "MediaDuration",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "media_position",
+          "cSharpName": "MediaPosition",
+          "clrType": "System.Double"
+        },
+        {
+          "jsonName": "media_position_updated_at",
+          "cSharpName": "MediaPositionUpdatedAt",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "media_title",
+          "cSharpName": "MediaTitle",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "media_album_name",
+          "cSharpName": "MediaAlbumName",
+          "clrType": "System.String"
+        },          
+        {
+          "jsonName": "media_image_url",
+          "cSharpName": "MediaImageUrl",
+          "clrType": "System.String"
+        },        
+        {
+          "jsonName": "media_artist",
+          "cSharpName": "MediaArtist",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "sound_mode_list",
+          "cSharpName": "SoundModeList",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },
+        {
+          "jsonName": "media_track",
+          "cSharpName": "MediaTrack",
+          "clrType": "System.Object"
+        },
+        {
+          "jsonName": "shuffle",
+          "cSharpName": "Shuffle",
+          "clrType": "System.Boolean"
+        },
+        {
+          "jsonName": "repeat",
+          "cSharpName": "Repeat",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "source_list",
+          "cSharpName": "SourceList",
+          "clrType": "System.Collections.Generic.IReadOnlyList\u00601[System.String]"
+        },
+        {
+          "jsonName": "source",
+          "cSharpName": "Source",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "adb_response",
+          "cSharpName": "AdbResponse",
+          "clrType": "System.Object"
+        },
+        {
+          "jsonName": "hdmi_input",
+          "cSharpName": "HdmiInput",
+          "clrType": "System.Object"
+        },
+        {
+          "jsonName": "sound_mode",
+          "cSharpName": "SoundMode",
+          "clrType": "System.String"
+        },
+        {
+          "jsonName": "sound_mode_raw",
+          "cSharpName": "SoundModeRaw",
+          "clrType": "System.String"
+        }
+      ]
     }
   ]
 }

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/EntityMetaDataMerger.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/MetaData/EntityMetaData/EntityMetaDataMerger.cs
@@ -1,12 +1,15 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json.Serialization;
 using NetDaemon.HassModel.Entities.Core;
 
 namespace NetDaemon.HassModel.CodeGenerator;
-
 internal static class EntityMetaDataMerger
 {
+    // We have to disable warnings. SuppressMessage attribute did not work.
+#pragma warning disable CS0618 // Type or member is obsolete
     private static readonly Type[] _possibleBaseTypes = typeof(LightAttributesBase).Assembly.GetTypes();
+#pragma warning restore CS0618 // Type or member is obsolete
     
     // We need to merge the previously saved metadata with the current metadata from HA
     // We do this because sometimes entities do not provide all their attributes,

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGenTestHelper.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGenTestHelper.cs
@@ -45,7 +45,8 @@ internal class CodeGenTestHelper
         var warningsOrErrors = emitResult.Diagnostics
             .Where(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning).ToList();
 
-        if (!warningsOrErrors.Any()) return;
+        // Ignore obsolete warnings
+        if (warningsOrErrors.All(n => n.Id == "CS0618")) return;
         
         var msg = new StringBuilder("Compile of generated code failed.\r\n");
         foreach (var diagnostic in warningsOrErrors)

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ControllerTest.cs
@@ -15,8 +15,10 @@ public class ControllerTest
         var result = await controller.LoadEntitiesMetaDataAsync();
 
         // ASSERT
-        result.Domains.Count.Should().Be(1);
+        result.Domains.Count.Should().Be(2);
         result.Domains.Single(x => x.Domain == "light").Should().NotBeNull();
         result.Domains.Single(x => x.Domain == "light").Attributes.SingleOrDefault(x => x.JsonName == "brightness").Should().NotBeNull();
+        result.Domains.Single(x => x.Domain == "media_player").Should().NotBeNull();
+        result.Domains.Single(x => x.Domain == "media_player").Attributes.SingleOrDefault(x => x.JsonName == "media_artist").Should().NotBeNull();
     }
 }

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -8,6 +8,7 @@
 ///     We use doubles even if the standard is integer to make the serializing more robust
 ///     since we cannot trust HA integrations use integers when supposed to
 /// </remarks>
+[Obsolete("Usage of attribute base classes are deprecated, default meta data is not used to replace it")]
 public record LightAttributesBase
 {
     /// <summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/LightAttributesBase.cs
@@ -8,7 +8,7 @@
 ///     We use doubles even if the standard is integer to make the serializing more robust
 ///     since we cannot trust HA integrations use integers when supposed to
 /// </remarks>
-[Obsolete("Usage of attribute base classes are deprecated, default meta data is not used to replace it")]
+[Obsolete("Usage of attribute base classes are deprecated, default meta data is now used to replace it")]
 public record LightAttributesBase
 {
     /// <summary>

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS1591
 #pragma warning disable CA1056
 
+[Obsolete("Usage of attribute base classes are deprecated, default meta data is not used to replace it")]
 public record MediaPlayerAttributesBase
 {
     [JsonPropertyName("app_id")]

--- a/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
+++ b/src/HassModel/NetDeamon.HassModel/Entities/Core/MediaPlayerAttributesBase.cs
@@ -2,7 +2,7 @@
 #pragma warning disable CS1591
 #pragma warning disable CA1056
 
-[Obsolete("Usage of attribute base classes are deprecated, default meta data is not used to replace it")]
+[Obsolete("Usage of attribute base classes are deprecated, default meta data is now used to replace it")]
 public record MediaPlayerAttributesBase
 {
     [JsonPropertyName("app_id")]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds media player defaults to the default meta generation. Deprecates the attributes base classes for light and media_player.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs