### PR TITLE
Better handling of faulty unloading of appa

### DIFF
--- a/src/AppModel/NetDaemon.AppModel.Tests/Fixtures/Local/AppThatTakesASlowTimeToDispose.cs
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Fixtures/Local/AppThatTakesASlowTimeToDispose.cs
@@ -1,0 +1,17 @@
+
+namespace LocalApps;
+
+
+[NetDaemonApp]
+public class SlowDisposableApp : IDisposable
+{
+    public SlowDisposableApp()
+    {
+    }
+
+    public void Dispose()
+    {
+        Thread.Sleep(3500);
+    }
+}
+

--- a/src/AppModel/NetDaemon.AppModel/Internal/AppModelContext.cs
+++ b/src/AppModel/NetDaemon.AppModel/Internal/AppModelContext.cs
@@ -26,7 +26,7 @@ internal class AppModelContext : IAppModelContext
     {
         var factories = _appFactoryProviders.SelectMany(provider => provider.GetAppFactories()).ToList();
 
-        var filteredFactories =  _focusFilter.FilterFocusApps(factories);
+        var filteredFactories = _focusFilter.FilterFocusApps(factories);
 
         foreach (var factory in filteredFactories)
         {
@@ -44,11 +44,33 @@ internal class AppModelContext : IAppModelContext
         if (_isDisposed) return;
         _isDisposed = true;
 
-        foreach (var appInstance in _applications)
-        {
-            await appInstance.DisposeAsync().ConfigureAwait(false);
-        }
+        // Get all tasks for disposing the apps with a timeout
+        var disposeTasks = _applications.Select(app => app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(3))).ToList();
 
+        // We cannot use Task WhenAll here since we do not want to halt on a single exception
+        // but rather log all exceptions and make sure all apps are disposed properly
+        foreach (var disposeTask in disposeTasks)
+        {
+            try
+            {
+               await disposeTask.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                var indexOfApp = disposeTasks.IndexOf(disposeTask);
+                var app = _applications[indexOfApp];
+
+                if (e is TimeoutException)
+                    _logger.LogError("Unloading the app '{App}' takes longer than expected, please check for blocking code", app.Id);
+                else
+                    _logger.LogError(disposeTask.Exception, "Unloading the app '{App}' failed", app.Id);
+            }
+        }
+        _logger.LogInformation("All apps are disposed");
         _applications.Clear();
+
+        // We need to force a garbage collection here to make sure all apps are freed from memory
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
     }
 }

--- a/src/AppModel/NetDaemon.AppModel/Internal/AppModelContext.cs
+++ b/src/AppModel/NetDaemon.AppModel/Internal/AppModelContext.cs
@@ -45,32 +45,10 @@ internal class AppModelContext : IAppModelContext
         _isDisposed = true;
 
         // Get all tasks for disposing the apps with a timeout
-        var disposeTasks = _applications.Select(app => app.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(3))).ToList();
+        var disposeTasks = _applications.Select(app => app.DisposeAsync().AsTask()).ToList();
 
-        // We cannot use Task WhenAll here since we do not want to halt on a single exception
-        // but rather log all exceptions and make sure all apps are disposed properly
-        foreach (var disposeTask in disposeTasks)
-        {
-            try
-            {
-               await disposeTask.ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                var indexOfApp = disposeTasks.IndexOf(disposeTask);
-                var app = _applications[indexOfApp];
+        await Task.WhenAll(disposeTasks).ConfigureAwait(false);
 
-                if (e is TimeoutException)
-                    _logger.LogError("Unloading the app '{App}' takes longer than expected, please check for blocking code", app.Id);
-                else
-                    _logger.LogError(disposeTask.Exception, "Unloading the app '{App}' failed", app.Id);
-            }
-        }
-        _logger.LogInformation("All apps are disposed");
         _applications.Clear();
-
-        // We need to force a garbage collection here to make sure all apps are freed from memory
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
     }
 }

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -152,7 +152,14 @@ internal class NetDaemonRuntime : IRuntime
                 reasonString, TimeoutInSeconds);
         }
 
-        await DisposeApplicationsAsync().ConfigureAwait(false);
+        try
+        {
+            await DisposeApplicationsAsync().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error disposing applications");
+        }
         IsConnected = false;
     }
 

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -85,6 +85,14 @@ internal class NetDaemonRuntime : IRuntime
         CancellationToken cancelToken)
     {
         _logger.LogInformation("Successfully connected to Home Assistant");
+
+        if (_applicationModelContext is not null)
+        {
+            // Something wrong with unloading and disposing apps on restart of HA, we need to prevent apps loading multiple times
+            _logger.LogWarning("Applications were not successfully disposed during restart, skippin loading apps again");
+            return;
+        }
+
         IsConnected = true;
 
         await _cacheManager.InitializeAsync(cancelToken).ConfigureAwait(false);
@@ -108,13 +116,13 @@ internal class NetDaemonRuntime : IRuntime
                     Path.GetFullPath(_locationSettings.Value.ApplicationConfigurationFolder));
             else
                 _logger.LogDebug("Loading applications with no configuration folder");
-            
+
             _applicationModelContext = await appModel.LoadNewApplicationContext(CancellationToken.None).ConfigureAwait(false);
 
             // Handle state change for apps if registered
             var appStateHandler = _serviceProvider.GetService<IHandleHomeAssistantAppStateUpdates>();
             if (appStateHandler == null) return;
-            
+
             await appStateHandler.InitializeAsync(haConnection, _applicationModelContext);
         }
         catch (Exception e)
@@ -153,7 +161,7 @@ internal class NetDaemonRuntime : IRuntime
         if (_applicationModelContext is not null)
         {
             await _applicationModelContext.DisposeAsync();
-            
+
             _applicationModelContext = null;
         }
     }
@@ -163,7 +171,7 @@ internal class NetDaemonRuntime : IRuntime
     {
         if (_isDisposed) return;
         _isDisposed = true;
-        
+
         await DisposeApplicationsAsync().ConfigureAwait(false);
         _runnerCancelationSource?.Cancel();
         try

--- a/src/debug/DebugHost/apps/HelloApp/HelloApp.cs
+++ b/src/debug/DebugHost/apps/HelloApp/HelloApp.cs
@@ -23,9 +23,10 @@ public sealed class HelloApp : IAsyncDisposable
         // ha?.CallService("notify", "persistent_notification", data: new { message = "Notify me", title = "Hello world!" });
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        await Task.Delay(5000);
         _logger.LogInformation("disposed app");
-        return ValueTask.CompletedTask;
+        //return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We currently do not handle unloading of apps in a robust way,  This PR makes this better by:

- Make sure we log if unloading/disposing apps takes more than 3 seconds
- Make disposing apps concurrent so non faulty apps get disposed correctly
- Make sure that if disposing of apps fails, new instances of apps will not be created
- Make sure we always log errors on disconnect 

There are still a risk that the faulty blocking app could be initialized a second time on HA restart but not without it being logged at least. This require some more re-design and I will check this out in V4 of the runtime.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs