### PR TITLE
Add EnumerateAll() to generated Entities Classes

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EnumerateAllGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EnumerateAllGenerator.cs
@@ -12,7 +12,7 @@ internal static class EnumerateAllGenerator
                                                                            _haContext.GetAllEntities()
                                                                                .Where(e => e.EntityId.StartsWith("{domainPrefix}."))
                                                                                .Select(e => new {entityClassName}(e));
-                                                                       """);
+                                                                       """)!;
 
         return domainPrefix == "sensor" ? [enumerateAllMethod, ..GenerateEnumerateAllSensor()] : [enumerateAllMethod];
     }
@@ -30,7 +30,7 @@ internal static class EnumerateAllGenerator
                                                      .Where(e => e.EntityId.StartsWith("sensor.")
                                                              && !(e.EntityState?.AttributesJson?.TryGetProperty("unit_of_measurement", out _) ?? false))
                                                      .Select(e => new SensorEntity(e));
-                                             """),
+                                             """)!,
 
         SyntaxFactory.ParseMemberDeclaration("""
                                              /// <summary>Enumerates all numeric sensor entities currently registered (at runtime) in Home Assistant as NumericSensorEntity</summary>
@@ -39,6 +39,6 @@ internal static class EnumerateAllGenerator
                                                      .Where(e => e.EntityId.StartsWith("sensor.")
                                                                  && (e.EntityState?.AttributesJson?.TryGetProperty("unit_of_measurement", out _) ?? false))
                                                      .Select(e => new NumericSensorEntity(e));
-                                             """)
+                                             """)!
     ];
 }

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EnumerateAllGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/EnumerateAllGenerator.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace NetDaemon.HassModel.CodeGenerator;
+
+internal static class EnumerateAllGenerator
+{
+    public static MemberDeclarationSyntax[] GenerateEnumerateMethods(string domainPrefix, string entityClassName)
+    {
+        var enumerateAllMethod = SyntaxFactory.ParseMemberDeclaration($"""
+                                                                       /// <summary>Enumerates all {domainPrefix} entities currently registered (at runtime) in Home Assistant as {entityClassName}</summary>
+                                                                       public IEnumerable<{entityClassName}> EnumerateAll() =>
+                                                                           _haContext.GetAllEntities()
+                                                                               .Where(e => e.EntityId.StartsWith("{domainPrefix}."))
+                                                                               .Select(e => new {entityClassName}(e));
+                                                                       """);
+
+        return domainPrefix == "sensor" ? [enumerateAllMethod, ..GenerateEnumerateAllSensor()] : [enumerateAllMethod];
+    }
+
+    /// <summary>
+    /// For sensors we also add EnumerateAllNonNumeric and EnumerateAllNumeric
+    /// </summary>
+    /// <returns></returns>
+    private static MemberDeclarationSyntax[] GenerateEnumerateAllSensor() =>
+    [
+        SyntaxFactory.ParseMemberDeclaration("""
+                                             /// <summary>Enumerates all non-numeric sensor entities currently registered (at runtime) in Home Assistant as SensorEntity</summary>
+                                             public IEnumerable<SensorEntity> EnumerateAllNonNumeric() =>
+                                                 _haContext.GetAllEntities()
+                                                     .Where(e => e.EntityId.StartsWith("sensor.")
+                                                             && !(e.EntityState?.AttributesJson?.TryGetProperty("unit_of_measurement", out _) ?? false))
+                                                     .Select(e => new SensorEntity(e));
+                                             """),
+
+        SyntaxFactory.ParseMemberDeclaration("""
+                                             /// <summary>Enumerates all numeric sensor entities currently registered (at runtime) in Home Assistant as NumericSensorEntity</summary>
+                                             public IEnumerable<NumericSensorEntity> EnumerateAllNumeric() =>
+                                                 _haContext.GetAllEntities()
+                                                     .Where(e => e.EntityId.StartsWith("sensor.")
+                                                                 && (e.EntityState?.AttributesJson?.TryGetProperty("unit_of_measurement", out _) ?? false))
+                                                     .Select(e => new NumericSensorEntity(e));
+                                             """)
+    ];
+}

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Helpers/NamingHelper.cs
@@ -60,16 +60,17 @@ internal static class NamingHelper
         // Use short name if the type is in one of the using namespaces
         return UsingNamespaces.Any(u => type.Namespace == u) ? type.Name : type.FullName!;
     }
-    
+
     public static readonly string[] UsingNamespaces =
     {
         "System",
+        "System.Linq",
         "System.Collections.Generic",
         "Microsoft.Extensions.DependencyInjection",
         typeof(JsonPropertyNameAttribute).Namespace!,
         typeof(IHaContext).Namespace!,
         typeof(Entity).Namespace!,
-        // Have to suppress warning because of obsolete LightAttributesBase. Suppress message attribute did not work.  
+        // Have to suppress warning because of obsolete LightAttributesBase. Suppress message attribute did not work.
 #pragma warning disable CS0618 // Type or member is obsolete
         typeof(LightAttributesBase).Namespace!
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/CodeGeneratorTest.cs
@@ -145,6 +145,7 @@ public class CodeGeneratorTest
                         using NetDaemon.HassModel.Entities;
                         using NetDaemon.HassModel;
                         using RootNameSpace;
+                        using System.Collections.Generic;
 
                         public class Root
                         {
@@ -165,6 +166,10 @@ public class CodeGeneratorTest
 
                                 ProximityEntity homeProximity = entities.Proximity.Home;
                                 double? distance = homeProximity.State;
+
+                                IEnumerable<SensorEntity> allSensors = entities.Sensor.EnumerateAll();
+                                IEnumerable<SensorEntity> nonNumericSensors = entities.Sensor.EnumerateAllNonNumeric();
+                                IEnumerable<NumericSensorEntity> numericSensors = entities.Sensor.EnumerateAllNumeric();
                              }
                         }
                         """;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
So now finally you can do just do 

`entities.Light.EnumerateAll().Where(l => l.Area == "living").TurnOff();`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs