### PR TITLE
Fixed clean stopping when connection error halts the ending of runtime

### DIFF
--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -57,7 +57,7 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
                 _runnerCancellationSource.Token);
 
             // Make sure we only return after the connection is made and initialization is ready
-            await _startedAndConnected.Task;
+            await Task.WhenAny( _startedAndConnected.Task, _runnerTask);
         }
         catch (OperationCanceledException)
         {

--- a/src/Runtime/NetDaemon.Runtime/Internal/RuntimeService.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/RuntimeService.cs
@@ -24,4 +24,10 @@ internal class RuntimeService(IRuntime runtime, ILogger<RuntimeService> logger) 
         }
         _stoppingTokenSource.Dispose();
     }
+
+    public override void Dispose()
+    {
+        _stoppingTokenSource.Dispose();
+        base.Dispose();
+    }
 }

--- a/src/debug/DebugHost/apps/HelloApp/HelloApp.cs
+++ b/src/debug/DebugHost/apps/HelloApp/HelloApp.cs
@@ -21,10 +21,9 @@ public sealed class HelloApp : IAsyncDisposable
         ha?.CallService("notify", "persistent_notification", data: new { message = "Notify me", title = "Hello world!" });
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        await Task.Delay(5000);
         _logger.LogInformation("disposed app");
-        //return ValueTask.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This was an annoying bug that made the runtime wait infinite time if there was an error in the connection phase. 

The bug could potentially lead to deadlock situation where the service could not be stopped if there was a connection problem too. 

Something changed the timings with this change so I had to make a small delay before the integration tests will run or the state cache will not be populated and tests would fail. I really have no idea how to make it more robust without using delays. It is fixed for now but if the tests will be flaky I will have to look at a long term solution.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs