### PR TITLE
Make AddScopedHaContext public

### DIFF
--- a/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
+++ b/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
@@ -20,7 +20,7 @@ public static class DependencyInjectionSetup
             .ConfigureServices((_, services) => services.AddScopedHaContext());
     }
 
-    internal static void AddScopedHaContext(this IServiceCollection services)
+    public static void AddScopedHaContext(this IServiceCollection services)
     {
         services.AddSingleton<EntityStateCache>();
         services.AddSingleton<EntityAreaCache>();

--- a/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
+++ b/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
@@ -9,7 +9,7 @@ namespace NetDaemon.HassModel;
 public static class DependencyInjectionSetup
 {
     /// <summary>
-    /// Registers services for using the IHaContext interface scoped to NetDemonApps
+    /// Registers services for using the IHaContext interface scoped to NetDeamonApps
     /// </summary>
     public static IHostBuilder UseAppScopedHaContext(this IHostBuilder hostBuilder)
     {

--- a/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
+++ b/src/HassModel/NetDeamon.HassModel/DependencyInjectionSetup.cs
@@ -20,6 +20,9 @@ public static class DependencyInjectionSetup
             .ConfigureServices((_, services) => services.AddScopedHaContext());
     }
 
+    /// <summary>
+    /// Registers services for using the IHaContext interface scoped to NetDeamonApps
+    /// </summary>
     public static void AddScopedHaContext(this IServiceCollection services)
     {
         services.AddSingleton<EntityStateCache>();


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am changing the visibility of the `NetDaemon.HassModel.DependencyInjectionSetup.AddScopedHaContext` method to public.
For building a (web) application where I need to access a lot of HA states I would like to use the HassModel.
Currently I'm using this ugly hack that I want to change:
```csharp
 // Hack: Initialize Hass Model
var extensionType = typeof(DependencyInjectionSetup);
var methodInfo = extensionType.GetMethod("AddScopedHaContext",
    System.Reflection.BindingFlags.NonPublic
    | System.Reflection.BindingFlags.Static
)  ?? throw new Exception("Error injecting Hass Model");

methodInfo.Invoke(null, [builder.Services]);
```

In some scenarios (like new ASP.NET Core apps) we don't have an `IHostBuilder'. So the current available public method don't work.

To make this work, you also need a `IHostedService`. This is my example. I could also implement this on the repo with a different extension method:

```csharp
internal class HassHostedService(
    IOptions<HomeAssistantSettings> options,
    IHomeAssistantRunner haRunner,
    ICacheManager cacheManager,
    ILogger<HassHostedService> logger
) : IHostedService
{
    private CancellationTokenSource _cancellationTokenSource = new();

    public async Task StartAsync(CancellationToken cancellationToken)
    {
        var haSettings = options.Value;

        haRunner.OnConnect.SubscribeAsync(OnConnection);

        _ = haRunner.RunAsync(
             haSettings.Host,
             haSettings.Port,
             haSettings.Ssl,
             haSettings.Token,
             TimeSpan.FromSeconds(10),
             _cancellationTokenSource.Token
        );
    }

    private async Task OnConnection(IHomeAssistantConnection connection)
    {
        logger.LogInformation("Hass Connection initialized");
        await cacheManager.InitializeAsync(_cancellationTokenSource.Token);
    }

    public Task StopAsync(CancellationToken cancellationToken)
    {
        _cancellationTokenSource.Cancel();
        return Task.CompletedTask;
    }
}
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist] - *(Where is the checklist?)*
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works. - *(Not required)* 

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs