### PR TITLE
Add data to service extensions for services that lacks metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ codecover_merged.info
 # User-specific files
 .idea/
 appsettings.Development.json
+appsettings.development.json
 
 **/core
 
@@ -63,3 +64,8 @@ appsettings.Development.json
 # remove HA integration test files from git
 tests/Integration/HA/config/*
 !tests/Integration/HA/config/*.yaml
+
+# remove codegenerated files
+HomeAssistantGenerated.cs
+EntityMetaData.json
+ServicesMetaData.json

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ExtensionMethodsGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ExtensionMethodsGenerator.cs
@@ -85,9 +85,9 @@ internal static class ExtensionMethodsGenerator
     private static MemberDeclarationSyntax ExtensionMethodWithoutArguments(HassService service, string serviceName, string entityTypeName)
     {
         return ParseMemberDeclaration($$"""
-                    public static void {{GetServiceMethodName(serviceName)}}(this {{entityTypeName}} target)
+                    public static void {{GetServiceMethodName(serviceName)}}(this {{entityTypeName}} target, object? data = null)
                     {
-                        target.CallService("{{serviceName}}");
+                        target.CallService("{{serviceName}}", data);
                     }
                     """)!
             .WithSummaryComment(service.Description);

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/Generator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/Generator.cs
@@ -53,7 +53,7 @@ internal static class Generator
         // In the template projects we provided a convenience powershell script that will update
         // the codegen and nugets to latest versions update_all_dependencies.ps1.
         //
-        // For more information: https://netdaemon.xyz/docs/v3/hass_model/hass_model_codegen
+        // For more information: https://netdaemon.xyz/docs/user/hass_model/hass_model_codegen
         // For more information about NetDaemon: https://netdaemon.xyz/
         // </auto-generated>
         //------------------------------------------------------------------------------";

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -97,7 +97,14 @@ internal static class ServicesGenerator
 
         if (serviceArguments is null)
         {
-            targetParam = "object? data";
+            if (service.Target is not null)
+            {
+                targetParam = $"{targetParam}, object? data = null";
+            }
+            else
+            {
+                targetParam = "object? data = null";
+            }
             targetArg = "null, data";
             // method without arguments
             yield return ParseMemberDeclaration($$"""

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -97,6 +97,8 @@ internal static class ServicesGenerator
 
         if (serviceArguments is null)
         {
+            targetParam = "object? data";
+            targetArg = "null, data";
             // method without arguments
             yield return ParseMemberDeclaration($$"""
                         void {{serviceMethodName}}({{targetParam}})

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -97,21 +97,11 @@ internal static class ServicesGenerator
 
         if (serviceArguments is null)
         {
-            if (service.Target is not null)
-            {
-                targetParam = $"{targetParam}, object? data = null";
-                targetArg = "target, data";
-            }
-            else
-            {
-                targetParam = "object? data = null";
-                targetArg = "null, data";
-            }
             // method without arguments
             yield return ParseMemberDeclaration($$"""
-                        void {{serviceMethodName}}({{targetParam}})
+                        void {{serviceMethodName}}({{CommaSeparateNonEmpty(targetParam, "object? data = null")}})
                         {
-                            {{haContextVariableName}}.CallService("{{domain}}", "{{serviceName}}", {{targetArg}});
+                            {{haContextVariableName}}.CallService("{{domain}}", "{{serviceName}}", {{CommaSeparateNonEmpty(targetArg, "data")}});
                         }
                         """)!
                 .ToPublic()
@@ -122,7 +112,7 @@ internal static class ServicesGenerator
         {
             // method using arguments object
             yield return ParseMemberDeclaration($$"""
-                        void {{serviceMethodName}}({{JoinList(targetParam, serviceArguments.TypeName)}} data)
+                        void {{serviceMethodName}}({{CommaSeparateNonEmpty(targetParam, serviceArguments.TypeName)}} data)
                         {
                             {{haContextVariableName}}.CallService("{{domain}}", "{{serviceName}}", {{targetArg}}, data);
                         }
@@ -133,7 +123,7 @@ internal static class ServicesGenerator
 
             // method using arguments as separate parameters
             yield return ParseMemberDeclaration($$"""
-                        void {{serviceMethodName}}({{JoinList(targetParam, serviceArguments.GetParametersList())}})
+                        void {{serviceMethodName}}({{CommaSeparateNonEmpty(targetParam, serviceArguments.GetParametersList())}})
                         {
                             {{haContextVariableName}}.CallService("{{domain}}", "{{serviceName}}", {{targetArg}}, {{serviceArguments.GetNewServiceArgumentsTypeExpression()}});
                         }
@@ -145,5 +135,5 @@ internal static class ServicesGenerator
         }
     }
 
-    private static string JoinList(params string?[] args) => string.Join(", ", args.Where(s => !string.IsNullOrEmpty(s)));
+    private static string CommaSeparateNonEmpty(params string?[] args) => string.Join(", ", args.Where(s => !string.IsNullOrEmpty(s)));
 }

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -100,12 +100,13 @@ internal static class ServicesGenerator
             if (service.Target is not null)
             {
                 targetParam = $"{targetParam}, object? data = null";
+                targetArg = "target, data";
             }
             else
             {
                 targetParam = "object? data = null";
+                targetArg = "null, data";
             }
-            targetArg = "null, data";
             // method without arguments
             yield return ParseMemberDeclaration($$"""
                         void {{serviceMethodName}}({{targetParam}})

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServicesGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServicesGeneratorTest.cs
@@ -101,6 +101,9 @@ public class ServicesGeneratorTest
                         }
 
                     },
+                    new() {
+                        Service = "reload",
+                    },
                 ]
             }
         };
@@ -121,6 +124,9 @@ public class ServicesGeneratorTest
 
                             s.Script.TurnOff(new ServiceTarget());
                             s.Script.TurnOff(new ServiceTarget(), new { });
+
+                            s.Script.Reload();
+                            s.Script.Reload(new { });
 
                             ScriptEntity script = new RootNameSpace.ScriptEntity(ha, "script.testScript");
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By adding the possibility to add custom data for services generated as extension methods on entities we can support service calls for services that does not provide metadata.

Example:
Calling a script can be called with custom data but since it lacks metadata the codegenerator generates empty calls.

Before:
```csharp
public static class ScriptEntityExtensionMethods
{
...

    ///<summary>Runs the sequence of actions defined in a script.</summary>
    public static void TurnOn(this IScriptEntityCore target)
    {
        target.CallService("turn_on");
    }
...
}
```
After:
```csharp
public static class ScriptEntityExtensionMethods
{
...

    ///<summary>Runs the sequence of actions defined in a script.</summary>
    public static void TurnOn(this IScriptEntityCore target, object? data = null)
    {
        target.CallService("turn_on", data);
    }
...
}
```

Also the same changes to servicecall. We add a data to service calls with no metadata but keeps the one  with metadata the same:

Example of new generated optional data provided.
```csharp
public partial class ScriptServices
{
    private readonly IHaContext _haContext;
    public ScriptServices(IHaContext haContext)
    {
        _haContext = haContext;
    }

    ///<summary>Reloads all the available scripts.</summary>
    public void Reload(object? data = null)
    {
        _haContext.CallService("script", "reload", null, data);
    }

    public void Setnightmode(object? data = null)
    {
        _haContext.CallService("script", "setnightmode", null, data);
    }

    ///<summary>Toggle a script. Starts it, if isn&apos;t running, stops it otherwise.</summary>
    ///<param name="target">The target for this service call</param>
    public void Toggle(ServiceTarget target, object? data = null)
    {
        _haContext.CallService("script", "toggle", target, data);
    }

    ///<summary>Stops a running script.</summary>
    ///<param name="target">The target for this service call</param>
    public void TurnOff(ServiceTarget target, object? data = null)
    {
        _haContext.CallService("script", "turn_off", target, data);
    }

    ///<summary>Runs the sequence of actions defined in a script.</summary>
    ///<param name="target">The target for this service call</param>
    public void TurnOn(ServiceTarget target, object? data = null)
    {
        _haContext.CallService("script", "turn_on", target, data);
    }
}
```



The code should not be breaking because of the optional data parameter.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)c
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs