### PR TITLE
Deprecates the SetEntityState in the HassModel.Integration assembly

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Integration/IntegrationHaContextExtensions.cs
+++ b/src/HassModel/NetDaemon.HassModel.Integration/IntegrationHaContextExtensions.cs
@@ -35,13 +35,14 @@ public static class IntegrationHaContextExtensions
     /// <param name="entityId">EntityId of the entity to create</param>
     /// <param name="state">Entity state</param>
     /// <param name="attributes">Entity attributes</param>
+    [Obsolete("SetEntityState is deprecated, use the MQTT extension instead to create entities.")]
     public static void SetEntityState(this IHaContext haContext, string entityId, string state,
         object? attributes = null)
     {
         ArgumentNullException.ThrowIfNull(haContext);
         var currentState = haContext.GetState(entityId);
         var service = currentState is null ? "entity_create" : "entity_update";
-        // We have an integration that will help persist 
+        // We have an integration that will help persist
         haContext.CallService("netdaemon", service,
             data: new
             {

--- a/src/HassModel/NetDaemon.HassModel.Tests/.editorconfig
+++ b/src/HassModel/NetDaemon.HassModel.Tests/.editorconfig
@@ -2,4 +2,4 @@
 dotnet_diagnostic.xUnit1030.severity = none
 # Warning CA1861 : Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861)
 dotnet_diagnostic.CA1861.severity= none
-
+dotnet_diagnostic.CS0618.severity = none


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We have a preferred way to create entities using the MQTT extension. The integration used internal APIs and are bound to break at some point. Also we should not have multiple ways to do things that we have to maintain. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs