### PR TITLE
Propagate more Device and Entity properties

### DIFF
--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
@@ -18,4 +18,9 @@ public record HassDevice
     [JsonPropertyName("name_by_user")] public string? NameByUser { get; init; }
 
     [JsonPropertyName("labels")] public IReadOnlyList<string> Labels { get; init; } = [];
+
+    [JsonPropertyName("configuration_url")] public string? ConfigurationUrl { get; init; }
+    [JsonPropertyName("hw_version")] public string? HardwareVersion { get; init; }
+    [JsonPropertyName("sw_version")] public string? SoftwareVersion { get; init; }
+    [JsonPropertyName("serial_number")] public string? SerialNumber { get; init; }
 }

--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
@@ -19,7 +19,9 @@ public record HassDevice
 
     [JsonPropertyName("labels")] public IReadOnlyList<string> Labels { get; init; } = [];
 
+    #pragma warning disable CA1056 // It's ok for this URL to be a string
     [JsonPropertyName("configuration_url")] public string? ConfigurationUrl { get; init; }
+    #pragma warning restore CA1056
     [JsonPropertyName("hw_version")] public string? HardwareVersion { get; init; }
     [JsonPropertyName("sw_version")] public string? SoftwareVersion { get; init; }
     [JsonPropertyName("serial_number")] public string? SerialNumber { get; init; }

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -75,7 +75,13 @@ internal static class HassObjectMapper
             Name = hassDevice.Name,
             Id = hassDevice.Id ?? "Unavailable",
             Area = hassDevice.AreaId is null ? null : registry.GetArea(hassDevice.AreaId),
-            Labels = hassDevice.Labels.Select(registry.GetLabel).OfType<Label>().ToList()
+            Labels = hassDevice.Labels.Select(registry.GetLabel).OfType<Label>().ToList(),
+            Manufacturer = hassDevice.Manufacturer,
+            Model = hassDevice.Model,
+            ConfigurationUrl = hassDevice.ConfigurationUrl,
+            SerialNumber = hassDevice.SerialNumber,
+            HardwareVersion = hassDevice.HardwareVersion,
+            SoftwareVersion = hassDevice.SoftwareVersion
         };
     }
 
@@ -113,6 +119,7 @@ internal static class HassObjectMapper
             Area = areaId is null ? null : registry.GetArea(areaId),
             Device = device,
             Labels = hassEntity.Labels.Select(registry.GetLabel).OfType<Label>().ToList(),
+            Platform = hassEntity.Platform,
         };
     }
 

--- a/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
@@ -36,4 +36,34 @@ public record Device
     /// The Labels of this Device
     /// </summary>
     public IReadOnlyCollection<Label> Labels { get; init; } = Array.Empty<Label>();
+
+    /// <summary>
+    /// The manufacturer of this Device, if available
+    /// </summary>
+    public string? Manufacturer { get; init; }
+
+    /// <summary>
+    /// The model of this Device, if available
+    /// </summary>
+    public string? Model { get; init; }
+
+    /// <summary>
+    /// A URL on which the device or service can be configured
+    /// </summary>
+    public string? ConfigurationUrl { get; init; }
+
+    /// <summary>
+    /// The hardware version of this Device, if available
+    /// </summary>
+    public string? HardwareVersion { get; init; }
+
+    /// <summary>
+    /// The software version of this Device, if available
+    /// </summary>
+    public string? SoftwareVersion { get; init; }
+
+    /// <summary>
+    /// The serial number of this Device, if available
+    /// </summary>
+    public string? SerialNumber { get; init; }
 }

--- a/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
@@ -50,7 +50,9 @@ public record Device
     /// <summary>
     /// A URL on which the device or service can be configured
     /// </summary>
+    #pragma warning disable CA1056 // It's ok for this URL to be a string
     public string? ConfigurationUrl { get; init; }
+    #pragma warning restore CA1056
 
     /// <summary>
     /// The hardware version of this Device, if available

--- a/src/HassModel/NetDeamon.HassModel/Registry/EntityRegistration.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/EntityRegistration.cs
@@ -29,4 +29,9 @@ public record EntityRegistration
     /// The Labels of this Entity
     /// </summary>
     public IReadOnlyCollection<Label> Labels { get; init; } = Array.Empty<Label>();
+
+    /// <summary>
+    /// An identifier for the integration that created this Entity
+    /// </summary>
+    public string? Platform { get; init; }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I mentioned on Discord a few days ago that I have a use case where it would be helpful to be able to get Manufacturer and Model information for some devices, or to check which integration added an entity.  In my case, I have an entity that I looked up by label, and it could have one of a handful of services that could be used to interact with it. I'd like to find a way to decide which service to use based only on the entity itself, which is much easier if I can tell specifically what kind of device it is.

The data I needed is actually already being provided by the Home Assistant API, it just wasn't being propagated up to the registry objects. This change adds the missing fields

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs