### PR TITLE
Support enums with underlying types other than int32 in yaml config

### DIFF
--- a/src/AppModel/NetDaemon.AppModel.Tests/Config/ConfigurationBinderTests.cs
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Config/ConfigurationBinderTests.cs
@@ -89,6 +89,17 @@ public class ConfigurationBinderTests
     }
 
     [Fact]
+    public void TestAddYamlConfigGetsEnumWithUnderlyingTypeCorrectly()
+    {
+        // ARRANGE
+        // ACT
+        var config = GetObjectFromSection<IEnumerable<TestShortEnum>>("AnotherTestShortEnum");
+        // CHECK
+        config!.Should().HaveCount(2);
+        Enum.GetUnderlyingType(config!.First().GetType()).Should().Be(typeof(ushort));
+    }
+
+    [Fact]
     public void TestAddYamlConfigGetsDictionaryCorrectly()
     {
         // ARRANGE
@@ -156,6 +167,12 @@ public class ConfigurationBinderTests
     }
 
     internal enum TestEnum
+    {
+        Enum1,
+        Enum2
+    }
+
+    internal enum TestShortEnum : ushort
     {
         Enum1,
         Enum2

--- a/src/AppModel/NetDaemon.AppModel.Tests/Config/Fixtures/CollectionTestsFixture.yaml
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Config/Fixtures/CollectionTestsFixture.yaml
@@ -52,3 +52,7 @@ AnotherTestArray:
 AnotherTestEnum:
   - Enum1
   - Enum2
+
+AnotherTestShortEnum:
+  - Enum1
+  - Enum2

--- a/src/AppModel/NetDaemon.AppModel/Internal/Config/ConfigurationBinding.cs
+++ b/src/AppModel/NetDaemon.AppModel/Internal/Config/ConfigurationBinding.cs
@@ -265,7 +265,8 @@ internal class ConfigurationBinding : IConfigurationBinding
             }
             else if (keyTypeIsEnum)
             {
-                var key = Convert.ToInt32(Enum.Parse(keyType, child.Key), CultureInfo.InvariantCulture);
+                var intType = Enum.GetUnderlyingType(keyType);
+                var key = Convert.ChangeType(Enum.Parse(keyType, child.Key), intType, CultureInfo.InvariantCulture);
                 setter.SetValue(dictionary, item, [key]);
             }
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While adding some yaml config to my app, I discovered that enum values could be parsed only if they had `Int32` as an underlying type. This change modifies the config parsing to allow enums with other underlying types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code compiles without warnings (code quality chek)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[docs-repository]: https://github.com/net-daemon/docs