### PR TITLE
Add converter to make sure we have a string value when expect it

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/Json/EnsureStringConverterTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/Json/EnsureStringConverterTests.cs
@@ -1,0 +1,69 @@
+
+namespace NetDaemon.HassClient.Tests.Json;
+
+public class EnsureStringConverterTests
+{
+    /// <summary>
+    ///     Default Json serialization options, Hass expects intended
+    /// </summary>
+    private readonly JsonSerializerOptions _defaultSerializerOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    [Fact]
+    public void TestConvertAValidString()
+    {
+        const string jsonDevice = @"
+        {
+            ""config_entries"": [],
+            ""connections"": [],
+            ""manufacturer"": ""Google Inc."",
+            ""model"": 123123,
+            ""name"": 123,
+            ""serial_number"": ""1.0"",
+            ""sw_version"": ""100"",
+            ""hw_version"": null,
+            ""id"": ""42cdda32a2a3428e86c2e27699d79ead"",
+            ""via_device_id"": null,
+            ""area_id"": null,
+            ""name_by_user"": null
+        }
+        ";
+        var hassDevice = JsonSerializer.Deserialize<HassDevice>(jsonDevice, _defaultSerializerOptions);
+        hassDevice!.SerialNumber.Should().Be("1.0");
+        hassDevice!.SoftwareVersion.Should().Be("100");
+        hassDevice!.HardwareVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public void TestConverAInvalidString()
+    {
+        const string jsonDevice = @"
+        {
+            ""config_entries"": [],
+            ""connections"": [],
+            ""model"": ""Chromecast"",
+            ""serial_number"": [""1.0"", ""2.0""],
+            ""name"": ""My TV"",
+            ""sw_version"": { ""attribute"": ""1.0"" },
+            ""manufacturer"": ""Google Inc."",
+            ""hw_version"": 100,
+            ""id"": ""42cdda32a2a3428e86c2e27699d79ead"",
+            ""via_device_id"": null,
+            ""area_id"": null,
+            ""name_by_user"": null
+        }
+        ";
+        var hassDevice = JsonSerializer.Deserialize<HassDevice>(jsonDevice, _defaultSerializerOptions);
+        hassDevice!.SerialNumber.Should().BeNull();
+        hassDevice!.SoftwareVersion.Should().BeNull();
+        hassDevice!.HardwareVersion.Should().BeNull();
+
+        // Make sure it is skipped correctly by checking the next property is read
+        hassDevice!.Manufacturer.Should().Be("Google Inc.");
+        hassDevice!.Id.Should().Be("42cdda32a2a3428e86c2e27699d79ead");
+        hassDevice!.Name.Should().Be("My TV");
+    }
+}

--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassDevice.cs
@@ -22,7 +22,10 @@ public record HassDevice
     #pragma warning disable CA1056 // It's ok for this URL to be a string
     [JsonPropertyName("configuration_url")] public string? ConfigurationUrl { get; init; }
     #pragma warning restore CA1056
+    [JsonConverter(typeof(EnsureStringConverter))]
     [JsonPropertyName("hw_version")] public string? HardwareVersion { get; init; }
+    [JsonConverter(typeof(EnsureStringConverter))]
     [JsonPropertyName("sw_version")] public string? SoftwareVersion { get; init; }
+    [JsonConverter(typeof(EnsureStringConverter))]
     [JsonPropertyName("serial_number")] public string? SerialNumber { get; init; }
 }

--- a/src/Client/NetDaemon.HassClient/Internal/Json/EnsureStringConverter.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Json/EnsureStringConverter.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+
+namespace NetDaemon.Client.Internal.Json;
+
+/// <summary>
+/// Converts a Json element that can be a string or a string array
+/// </summary>
+class EnsureStringConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            return reader.GetString() ?? throw new UnreachableException("Token is expected to be a string");
+        }
+
+        reader.Skip();
+        return null;
+    }
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options) => throw new NotSupportedException();
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add converters that returns null if expected string value is not a string when deserializing devices or the string if it is a valid string.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1125 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
