### PR TITLE
Make restart logic progressive and other small fixes

### DIFF
--- a/.github/workflows/push_nuget_prerelease.yml
+++ b/.github/workflows/push_nuget_prerelease.yml
@@ -49,7 +49,7 @@ jobs:
           dotnet-quality: 'preview'
       - name: 🔖 Set version number
         run: |
-          sed -i "/        private const string Version = /c\        private const string Version =  \"${{ steps.version.outputs.version }}-${{ github.event.inputs.pre }}-${{ steps.version.outputs.build }}\";" ${{github.workspace}}/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+          sed -i "/    private const string Version = /c\    private const string Version =  \"${{ steps.version.outputs.version }}-${{ github.event.inputs.pre }}-${{ steps.version.outputs.build }}\";" ${{github.workspace}}/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
       - name: 🎁 Pack
         run: dotnet pack NetDaemon.sln --configuration Release -p:PackageVersion=${{ steps.version.outputs.version }}-${{ github.event.inputs.pre }}-${{ steps.version.outputs.build }} -p:Version=${{ steps.version.outputs.version }}-${{ github.event.inputs.pre }}-${{ steps.version.outputs.build }}
       - name: 📨 Push to nuget

--- a/.github/workflows/tags_nuget.yml
+++ b/.github/workflows/tags_nuget.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: 🔖 Set version number
         run: |
-          sed -i '/        private const string Version = /c\        private const string Version =  "${{ steps.version.outputs.version }}";' ${{github.workspace}}/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+          sed -i '/    private const string Version = /c\    private const string Version =  "${{ steps.version.outputs.version }}";' ${{github.workspace}}/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
       - name: 🎁 Pack
         run: dotnet pack NetDaemon.sln --configuration Release -p:PackageVersion=${{ steps.version.outputs.version }} -p:Version=${{ steps.version.outputs.version }}
       - name: 📨 Push to nuget

--- a/src/Client/NetDaemon.HassClient.Debug/Service.cs
+++ b/src/Client/NetDaemon.HassClient.Debug/Service.cs
@@ -58,8 +58,7 @@ internal sealed class DebugService : BackgroundService
 
     private void OnHomeAssistantClientDisconnected(DisconnectReason reason)
     {
-        _logger.LogInformation("HassClient disconnected cause of {Reason}, connect retry in {Timeout} seconds",
-            TimeoutInSeconds, reason);
+        _logger.LogInformation("HassClient disconnected cause of {Reason}", reason);
         // Here you would typically cancel and dispose any functions
         // using the connection
         if (_connection is not null) _connection = null;

--- a/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
@@ -1,0 +1,38 @@
+namespace NetDaemon.HassClient.Tests.HelperTest;
+
+public class ProgressiveTimeoutTests
+{
+    [Fact]
+    public void TestProgressiveTimeout()
+    {
+        var progressiveTimeout = new ProgressiveTimeout(100, 1000, 2.0);
+        progressiveTimeout.GetNextTimeout().Should().Be(100);
+        progressiveTimeout.GetNextTimeout().Should().Be(200);
+        progressiveTimeout.GetNextTimeout().Should().Be(400);
+        progressiveTimeout.GetNextTimeout().Should().Be(800);
+        progressiveTimeout.GetNextTimeout().Should().Be(1000);
+        progressiveTimeout.GetNextTimeout().Should().Be(1000);
+        progressiveTimeout.GetNextTimeout().Should().Be(1000);
+    }
+
+    [Fact]
+    public void TestProgressiveTimeoutInputChecksThrows()
+    {
+        // Check that start timeout is alwasy greater than zero
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(0, 1000, 2.0));
+        // Check that max timeout is greater than start timeout
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(100, 99, 2.0));
+        // Check that increase factor is greater than 1
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(100, 1000, 1.0));
+    }
+
+    [Fact]
+    public void TestProgressiveTimeoutReset()
+    {
+        var progressiveTimeout = new ProgressiveTimeout(100, 1000, 2.0);
+        progressiveTimeout.GetNextTimeout().Should().Be(100);
+        progressiveTimeout.GetNextTimeout().Should().Be(200);
+        progressiveTimeout.Reset();
+        progressiveTimeout.GetNextTimeout().Should().Be(100);
+    }
+}

--- a/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
@@ -22,6 +22,8 @@ public class ProgressiveTimeoutTests
         Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.Zero, TimeSpan.FromSeconds(100), 2.0));
         // Check that max timeout is greater than start timeout
         Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(99), 2.0));
+        // Check that max timeout is not same as start timeout
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(100), 2.0));
         // Check that increase factor is greater than 1
         Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(100), 1.0));
     }

--- a/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HelperTest/ProgressiveTimoutTests.cs
@@ -5,34 +5,34 @@ public class ProgressiveTimeoutTests
     [Fact]
     public void TestProgressiveTimeout()
     {
-        var progressiveTimeout = new ProgressiveTimeout(100, 1000, 2.0);
-        progressiveTimeout.GetNextTimeout().Should().Be(100);
-        progressiveTimeout.GetNextTimeout().Should().Be(200);
-        progressiveTimeout.GetNextTimeout().Should().Be(400);
-        progressiveTimeout.GetNextTimeout().Should().Be(800);
-        progressiveTimeout.GetNextTimeout().Should().Be(1000);
-        progressiveTimeout.GetNextTimeout().Should().Be(1000);
-        progressiveTimeout.GetNextTimeout().Should().Be(1000);
+        var progressiveTimeout = new ProgressiveTimeout(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(1000), 2.0);
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(100));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(200));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(400));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(800));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(1000));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(1000));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(1000));
     }
 
     [Fact]
     public void TestProgressiveTimeoutInputChecksThrows()
     {
         // Check that start timeout is alwasy greater than zero
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(0, 1000, 2.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.Zero, TimeSpan.FromSeconds(100), 2.0));
         // Check that max timeout is greater than start timeout
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(100, 99, 2.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(99), 2.0));
         // Check that increase factor is greater than 1
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(100, 1000, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgressiveTimeout(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(100), 1.0));
     }
 
     [Fact]
     public void TestProgressiveTimeoutReset()
     {
-        var progressiveTimeout = new ProgressiveTimeout(100, 1000, 2.0);
-        progressiveTimeout.GetNextTimeout().Should().Be(100);
-        progressiveTimeout.GetNextTimeout().Should().Be(200);
+        var progressiveTimeout = new ProgressiveTimeout(TimeSpan.FromSeconds(100), TimeSpan.FromSeconds(1000), 2.0);
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(100));
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(200));
         progressiveTimeout.Reset();
-        progressiveTimeout.GetNextTimeout().Should().Be(100);
+        progressiveTimeout.Timeout.Should().Be(TimeSpan.FromSeconds(100));
     }
 }

--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantRunnerTest/HomeAssistantRunnerTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantRunnerTest/HomeAssistantRunnerTests.cs
@@ -28,7 +28,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         var connection = await connectionTask.ConfigureAwait(false);
         DefaultRunner.CurrentConnection.Should().NotBeNull();
@@ -68,7 +68,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         var reason = await disconnectionTask.ConfigureAwait(false);
         DefaultRunner.CurrentConnection.Should().BeNull();
@@ -108,7 +108,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         var reason = await disconnectionTask.ConfigureAwait(false);
         DefaultRunner.CurrentConnection.Should().BeNull();
@@ -148,7 +148,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         var reason = await disconnectionTask.ConfigureAwait(false);
         DefaultRunner.CurrentConnection.Should().BeNull();
@@ -178,7 +178,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         // await DefaultRunner.DisposeAsync().ConfigureAwait(false);
         await cancelSource.CancelAsync();
@@ -218,7 +218,7 @@ public class HomeAssistantRunnerTests
             .ToTask();
 
         var runnerTask =
-            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100), cancelSource.Token);
+            DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1), cancelSource.Token);
 
         var reason = await disconnectionTask.ConfigureAwait(false);
         try
@@ -237,7 +237,7 @@ public class HomeAssistantRunnerTests
     [Fact]
     public async Task TestDisposeShouldDisconnectGracefully()
     {
-        var runnerTask = DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromMilliseconds(100),
+        var runnerTask = DefaultRunner.RunAsync("host", 0, false, "token", "wspath", TimeSpan.FromSeconds(1),
             CancellationToken.None);
 
         await Task.Delay(500);

--- a/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
@@ -1,7 +1,7 @@
 namespace NetDaemon.Client.Internal.Helpers;
 
 /// <summary>
-///  Progeressively increases timeout from a min valuye to a max value with a step
+///  Progeressively increases timeout from a min value to a max value with a step
 /// </summary>
 public class ProgressiveTimeout
 {

--- a/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
@@ -1,0 +1,41 @@
+namespace NetDaemon.Client.Internal.Helpers;
+
+/// <summary>
+///  Progeressively increases timeout from a min valuye to a max value with a step
+/// </summary>
+public class ProgressiveTimeout
+{
+    private readonly int _initialTimeout;
+    private readonly int _maxTimeout;
+    private readonly double _increaseFactor;
+    private int _currentTimeout;
+
+    public ProgressiveTimeout(int initialTimeout, int maxTimeout, double increaseFactor)
+    {
+        if (initialTimeout <= 0)
+            throw new ArgumentOutOfRangeException(nameof(initialTimeout), "Initial timeout must be greater than zero.");
+
+        if (maxTimeout < initialTimeout)
+            throw new ArgumentOutOfRangeException(nameof(maxTimeout), "Max timeout must be greater than or equal to initial timeout.");
+
+        if (increaseFactor <= 1)
+            throw new ArgumentOutOfRangeException(nameof(increaseFactor), "Increase factor must be greater than 1.");
+
+        _initialTimeout = initialTimeout;
+        _maxTimeout = maxTimeout;
+        _increaseFactor = increaseFactor;
+        _currentTimeout = initialTimeout;
+    }
+
+    public int GetNextTimeout()
+    {
+        int timeout = _currentTimeout;
+        _currentTimeout = Math.Min((int)(_currentTimeout * _increaseFactor), _maxTimeout);
+        return timeout;
+    }
+
+    public void Reset()
+    {
+        _currentTimeout = _initialTimeout;
+    }
+}

--- a/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
@@ -12,14 +12,9 @@ public class ProgressiveTimeout
 
     public ProgressiveTimeout(TimeSpan initialTimeout, TimeSpan maxTimeout, double increaseFactor)
     {
-        if (initialTimeout <= TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(initialTimeout), "Initial timeout must be greater than zero.");
-
-        if (maxTimeout < initialTimeout)
-            throw new ArgumentOutOfRangeException(nameof(maxTimeout), "Max timeout must be greater than or equal to initial timeout.");
-
-        if (increaseFactor <= 1)
-            throw new ArgumentOutOfRangeException(nameof(increaseFactor), "Increase factor must be greater than 1.");
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(initialTimeout, TimeSpan.Zero, nameof(initialTimeout));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(maxTimeout, initialTimeout, nameof(maxTimeout));
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(increaseFactor, 1, nameof(increaseFactor));
 
         _initialTimeout = initialTimeout;
         _maxTimeout = maxTimeout;

--- a/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/Helpers/ProgressiveTimeout.cs
@@ -5,14 +5,14 @@ namespace NetDaemon.Client.Internal.Helpers;
 /// </summary>
 public class ProgressiveTimeout
 {
-    private readonly int _initialTimeout;
-    private readonly int _maxTimeout;
+    private readonly TimeSpan _initialTimeout;
+    private readonly TimeSpan _maxTimeout;
     private readonly double _increaseFactor;
-    private int _currentTimeout;
+    private TimeSpan _currentTimeout;
 
-    public ProgressiveTimeout(int initialTimeout, int maxTimeout, double increaseFactor)
+    public ProgressiveTimeout(TimeSpan initialTimeout, TimeSpan maxTimeout, double increaseFactor)
     {
-        if (initialTimeout <= 0)
+        if (initialTimeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(initialTimeout), "Initial timeout must be greater than zero.");
 
         if (maxTimeout < initialTimeout)
@@ -27,11 +27,15 @@ public class ProgressiveTimeout
         _currentTimeout = initialTimeout;
     }
 
-    public int GetNextTimeout()
+    public TimeSpan Timeout
     {
-        int timeout = _currentTimeout;
-        _currentTimeout = Math.Min((int)(_currentTimeout * _increaseFactor), _maxTimeout);
-        return timeout;
+        get
+        {
+            var timeout = _currentTimeout;
+            var progressTimeout = _currentTimeout * _increaseFactor;
+            _currentTimeout = progressTimeout > _maxTimeout ? _maxTimeout : progressTimeout;
+            return timeout;
+        }
     }
 
     public void Reset()

--- a/src/Client/NetDaemon.HassClient/Internal/HomeAssistantRunner.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/HomeAssistantRunner.cs
@@ -12,6 +12,8 @@ internal class HomeAssistantRunner(IHomeAssistantClient client,
 
     private readonly Subject<DisconnectReason> _onDisconnectSubject = new();
 
+    private const int MaxTimeoutInSeconds = 80;
+
     private Task? _runTask;
 
     public IObservable<IHomeAssistantConnection> OnConnect => _onConnectSubject;
@@ -60,6 +62,7 @@ internal class HomeAssistantRunner(IHomeAssistantClient client,
     private async Task InternalRunAsync(string host, int port, bool ssl, string token, string websocketPath, TimeSpan timeout,
         CancellationToken cancelToken)
     {
+        var progressiveTimeout = new ProgressiveTimeout((int)timeout.TotalSeconds, MaxTimeoutInSeconds, 2.0);
         var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(_internalTokenSource.Token, cancelToken);
         while (!combinedToken.IsCancellationRequested)
         {
@@ -67,6 +70,9 @@ internal class HomeAssistantRunner(IHomeAssistantClient client,
             {
                 CurrentConnection = await client.ConnectAsync(host, port, ssl, token, websocketPath, combinedToken.Token)
                     .ConfigureAwait(false);
+                // We successfully connected so lets reset the progressiveTimeout
+                progressiveTimeout.Reset();
+
                 // Start the event processing before publish the connection
                 var eventsTask = CurrentConnection.WaitForConnectionToCloseAsync(combinedToken.Token);
                 _onConnectSubject.OnNext(CurrentConnection);
@@ -83,6 +89,8 @@ internal class HomeAssistantRunner(IHomeAssistantClient client,
             {
                 logger.LogInformation("Home Assistant is not ready yet!");
                 await DisposeConnectionAsync();
+                // We have an connection but waiting for Home Assistant to be ready so lets reset the progressiveTimeout
+                progressiveTimeout.Reset();
                 _onDisconnectSubject.OnNext(DisconnectReason.NotReady);
             }
             catch (OperationCanceledException)
@@ -112,8 +120,9 @@ internal class HomeAssistantRunner(IHomeAssistantClient client,
             if (combinedToken.IsCancellationRequested)
                 return; // If we are cancelled we should not retry
 
-            logger.LogInformation("Client connection failed, retrying in {Seconds} seconds...", timeout.TotalSeconds);
-            await Task.Delay(timeout, combinedToken.Token).ConfigureAwait(false);
+            var waitTimeout = progressiveTimeout.GetNextTimeout();
+            logger.LogInformation("Client connection failed, retrying in {Seconds} seconds...", waitTimeout);
+            await Task.Delay(TimeSpan.FromSeconds(waitTimeout), combinedToken.Token).ConfigureAwait(false);
         }
     }
 

--- a/src/HassModel/NetDeamon.HassModel/Internal/RegistryCache.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/RegistryCache.cs
@@ -46,7 +46,7 @@ internal class RegistryCache(IHomeAssistantRunner hassRunner, ILogger<RegistryCa
 
     private async Task RegistryUpdated(string eventType)
     {
-        logger.LogInformation("Received {Event}: Updating RegistryCache", eventType);
+        logger.LogDebug("Received {Event}: Updating RegistryCache", eventType);
 
         var task = eventType switch
         {

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Reflection;
 using NetDaemon.AppModel;
 using NetDaemon.HassModel;
 
@@ -12,8 +13,8 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
         ICacheManager cacheManager)
     : IRuntime
 {
-    private const string Version = "custom_compiled";
-    private const int TimeoutInSeconds = 30;
+    private const string Version = "local build";
+    private const int TimeoutInSeconds = 5;
 
     private readonly HomeAssistantSettings _haSettings = settings.Value;
 
@@ -25,7 +26,7 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
 
     // These internals are used primarily for testing purposes
     internal IReadOnlyCollection<IApplication> ApplicationInstances =>
-        _applicationModelContext?.Applications ?? Array.Empty<IApplication>();
+        _applicationModelContext?.Applications ?? [];
 
     private readonly TaskCompletionSource _startedAndConnected = new();
 
@@ -33,7 +34,7 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
 
     public async Task StartAsync(CancellationToken stoppingToken)
     {
-        logger.LogInformation($"Starting NetDaemon runtime version {Version}.");
+        logger.LogInformation("Starting NetDaemon runtime version {Version}.", Version);
 
         _stoppingToken = stoppingToken;
 
@@ -63,6 +64,7 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
             });
             // Make sure we only return after the connection is made and initialization is ready
             await _startedAndConnected.Task;
+            logger.LogInformation("NetDaemon runtime exiting.");
 
         }
         catch (OperationCanceledException)
@@ -147,8 +149,8 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
                 DisconnectReason.NotReady => "home assistant not ready yet",
                 _ => "unknown error"
             };
-            logger.LogInformation("Home Assistant disconnected due to {Reason}, connect retry in {TimeoutInSeconds} seconds",
-                reasonString, TimeoutInSeconds);
+            logger.LogInformation("Home Assistant disconnected due to {Reason}",
+                reasonString );
         }
 
         try
@@ -160,6 +162,12 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
             logger.LogError(e, "Error disposing applications");
         }
         IsConnected = false;
+
+        if (reason == DisconnectReason.Unauthorized)
+        {
+            // We will exit the runtime if the token is unauthorized to avoid hammering the server
+            _startedAndConnected.SetResult();
+        }
     }
 
     private async Task DisposeApplicationsAsync()

--- a/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/NetDaemonRuntime.cs
@@ -64,8 +64,6 @@ internal class NetDaemonRuntime(IHomeAssistantRunner homeAssistantRunner,
             });
             // Make sure we only return after the connection is made and initialization is ready
             await _startedAndConnected.Task;
-            logger.LogInformation("NetDaemon runtime exiting.");
-
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes in this PR:
### Progressive reconnect timeouts
To avoid too many tries it will increase the timeout per retry by a factor 2 starting with 5 seconds and max 80 seconds.

### The registry updated log will now be a debug log
Recent versions of HA updates the registries more often and possible flooding the outputlog. This log is now made a debug log instead.

### Fix the problem that the correct version does not show on start
The github action that push to Nuget did not successfully updated version information. The default message also changed  to reflect the actual behaviour. The version is not known when using a local built NetDaemon runtime. The version will then be `local build`. Offical built versions will show the correct version.

### Small fixes in restart logic
- The runtime stops when NetDaemon not able to authorize the token. This is same behavior as before but now the runtime shuts down too.
- Do not show timeout information on disconnect since this is also shown in the reconnect loop
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
