### PR TITLE
Make sure events are not forward if background task tracker is disposed

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Internal/AppScopedHaContextProviderTest.cs
@@ -269,7 +269,7 @@ public sealed class AppScopedHaContextProviderTest : IDisposable
         _hassEventSubjectMock.OnCompleted();
 
         await ((IAsyncDisposable)serviceScope).DisposeAsync();
-        eventObserverMock.Verify(m => m.OnNext(It.Is<Event>(e => e.Origin == "Test")));
+        eventObserverMock.Verify(m => m.OnNext(It.Is<Event>(e => e.Origin == "Test"))).Times(0);
         eventObserverMock.Verify(m => m.OnCompleted());
 
 

--- a/src/HassModel/NetDeamon.HassModel/Internal/QueuedObservable.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/QueuedObservable.cs
@@ -46,6 +46,8 @@ internal sealed class QueuedObservable<T> : IQueuedObservable<T>
         {
             try
             {
+                if (_isDisposed)
+                    break;
                 _subject.OnNext(@event);
             }
             catch (Exception e)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes that the `BackgroundTaskTracker` is disposed it should not forward any more events upstream to apps.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
