### PR TITLE
Fix the WhenStateIsSame should not call action when completed

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Tests/StateObservableExtensionsTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/StateObservableExtensionsTest.cs
@@ -21,7 +21,7 @@ public sealed class StateObservableExtensionsTest : IDisposable
     }
 
     [Fact]
-    public void TestThatWhenStateIsForDoesNotCallAction()
+    public void TestThatWhenStateIsForDoesNotCallActionWhenCompleted()
     {
         bool isCalled = false;
 
@@ -35,7 +35,7 @@ public sealed class StateObservableExtensionsTest : IDisposable
     }
 
     [Fact]
-    public void TestNumericEntityWhenStateIsForDoesNotCallAction()
+    public void TestNumericEntityWhenStateIsForDoesNotCallActionWhenCompleted()
     {
         bool isCalled = false;
 

--- a/src/HassModel/NetDaemon.HassModel.Tests/StateObservableExtensionsTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/StateObservableExtensionsTest.cs
@@ -21,6 +21,34 @@ public sealed class StateObservableExtensionsTest : IDisposable
     }
 
     [Fact]
+    public void TestThatWhenStateIsForDoesNotCallAction()
+    {
+        bool isCalled = false;
+
+        _subject.WhenStateIsFor(n => n?.State == "off", TimeSpan.FromSeconds(10), _testScheduler).Subscribe(_ => { isCalled = true;});
+
+        _subject.OnNext(new StateChange(new Entity(new Mock<IHaContext>().Object, ""), new EntityState { State = "on" }, new EntityState { State = "off" }));
+
+        _subject.OnCompleted();
+
+        isCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TestNumericEntityWhenStateIsForDoesNotCallAction()
+    {
+        bool isCalled = false;
+
+        _numericStateChangeObservable.WhenStateIsFor(n => n?.State > 20, TimeSpan.FromSeconds(10), _testScheduler).Subscribe(_ => { isCalled = true;});
+
+        _subject.OnNext(new StateChange(new Entity(new Mock<IHaContext>().Object, ""), new EntityState { State = "1" }, new EntityState { State = "30" }));
+
+        _subject.OnCompleted();
+
+        isCalled.Should().BeFalse();
+    }
+
+    [Fact]
     public void WhenNumStateIsForFiresInTime()
     {
         // wait for the sensor to be "on" for at least 10 ticks

--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -53,8 +53,7 @@ public static class StateObservableExtensions
             .Throttle(timeSpan, scheduler)
 
             // But only when the new state matches the predicate we emit it
-            .Where(e => predicate(e.New))
-            .Where(_ => isCompleted == false);
+            .Where(e => predicate(e.New) && isCompleted == false);
     }
 
     /// <summary>
@@ -78,7 +77,6 @@ public static class StateObservableExtensions
             .Do(_ => {}, () => isCompleted = true)
             .Where(e => predicate(e.Old) != predicate(e.New))
             .Throttle(timeSpan, scheduler)
-            .Where(e => predicate(e.New))
-            .Where(_ => isCompleted == false);
+            .Where(e => predicate(e.New) && isCompleted == false);
     }
 }

--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -42,7 +42,10 @@ public static class StateObservableExtensions
         ArgumentNullException.ThrowIfNull(predicate, nameof(predicate));
         ArgumentNullException.ThrowIfNull(scheduler, nameof(scheduler));
 
+        var isCompleted = false;
+
         return observable
+            .Do(_ => {}, () => isCompleted = true)
             // Only process changes that start or stop matching the predicate
             .Where(e => predicate(e.Old) != predicate(e.New))
 
@@ -50,7 +53,8 @@ public static class StateObservableExtensions
             .Throttle(timeSpan, scheduler)
 
             // But only when the new state matches the predicate we emit it
-            .Where(e => predicate(e.New));
+            .Where(e => predicate(e.New))
+            .Where(_ => isCompleted == false);
     }
 
     /// <summary>
@@ -68,9 +72,13 @@ public static class StateObservableExtensions
         ArgumentNullException.ThrowIfNull(predicate, nameof(predicate));
         ArgumentNullException.ThrowIfNull(scheduler, nameof(scheduler));
 
+        var isCompleted = false;
+
         return observable
+            .Do(_ => {}, () => isCompleted = true)
             .Where(e => predicate(e.Old) != predicate(e.New))
             .Throttle(timeSpan, scheduler)
-            .Where(e => predicate(e.New));
+            .Where(e => predicate(e.New))
+            .Where(_ => isCompleted == false);
     }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the problem that WhenStateIsSame calls the action when the observable is completed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
