### PR TITLE
Add extension function on observable to ignore OnComplete events

### DIFF
--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -8,7 +8,7 @@ namespace NetDaemon.HassModel;
 public static class StateObservableExtensions
 {
     /// <summary>
-    /// Ignores the completion of the observable
+    /// Ignores the OnCompletion event of the observable
     /// </summary>
     /// <remarks>
     /// In the case you do not want the action to be called when the observable is completed

--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -11,28 +11,13 @@ public static class StateObservableExtensions
     /// Ignores the OnCompletion event of the observable
     /// </summary>
     /// <remarks>
-    /// In the case you do not want the action to be called when the observable is completed
-    /// use this method before the use of other methods in the Observalble.
-    /// For example if you use Throttle and you want the action call not to be
-    /// run when you cancel the observable.
-    /// For use-cases where you want to wait for a specific state for a specific time
-    /// use <see cref="WhenStateIsFor"/> instead.
+    /// This can be used in combination with Throttle() to avoid events to be emitted when the
+    /// observable is completed (eg because the app is stopped). Use IgnoreOnComplete(). before
+    /// Throttle() to make sure Throttle will not send events when the app is stopping.
     /// </remarks>
     public static IObservable<T> IgnoreOnComplete<T>(this IObservable<T> source)
         => Observable.Create<T>(observer => source.Subscribe(observer.OnNext, observer.OnError));
 
-    // public static IObservable<StateChange> IgnoreOnComplete(
-    //     this IObservable<StateChange> observable)
-    // {
-    //     ArgumentNullException.ThrowIfNull(observable, nameof(observable));
-    //
-    //     var isCompleted = false;
-    //
-    //     return observable
-    //         .Do(_ => {}, () => isCompleted = true)
-    //         // But only when the new state matches the predicate we emit it
-    //         .Where(_ => isCompleted == false);
-    // }
     /// <summary>
     /// Waits for an EntityState to match a predicate for the specified time
     /// </summary>

--- a/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
+++ b/src/HassModel/NetDeamon.HassModel/StateObservableExtensions.cs
@@ -8,6 +8,32 @@ namespace NetDaemon.HassModel;
 public static class StateObservableExtensions
 {
     /// <summary>
+    /// Ignores the completion of the observable
+    /// </summary>
+    /// <remarks>
+    /// In the case you do not want the action to be called when the observable is completed
+    /// use this method before the use of other methods in the Observalble.
+    /// For example if you use Throttle and you want the action call not to be
+    /// run when you cancel the observable.
+    /// For use-cases where you want to wait for a specific state for a specific time
+    /// use <see cref="WhenStateIsFor"/> instead.
+    /// </remarks>
+    public static IObservable<T> IgnoreOnComplete<T>(this IObservable<T> source)
+        => Observable.Create<T>(observer => source.Subscribe(observer.OnNext, observer.OnError));
+
+    // public static IObservable<StateChange> IgnoreOnComplete(
+    //     this IObservable<StateChange> observable)
+    // {
+    //     ArgumentNullException.ThrowIfNull(observable, nameof(observable));
+    //
+    //     var isCompleted = false;
+    //
+    //     return observable
+    //         .Do(_ => {}, () => isCompleted = true)
+    //         // But only when the new state matches the predicate we emit it
+    //         .Where(_ => isCompleted == false);
+    // }
+    /// <summary>
     /// Waits for an EntityState to match a predicate for the specified time
     /// </summary>
     [Obsolete("Use the overload with IScheduler instead")]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->
In certain scenarios we might want to make sure the action is not called if the underlying Observable completes. For example advanced usages of Throttle you may want to make sure it never calls the action when an application is restarted. For most cases the extension method `WhenStateIsFor` should be used that are safe for this reason but if the user still wants to use Throttle for some reason and do not want it call the action prematurely before the timeout is due, this new method can be used before the Throttle.

Example:
```csharp
ha.StateChanges()
  .Where(...)
  .IgnoreOnComplete()
  .Throttle(...)
  .Subscribe(...);
```
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
