### PR TITLE
Expose Entity Registration Conversation Options

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/Integration/Testdata/result_get_entities.json
+++ b/src/Client/NetDaemon.HassClient.Tests/Integration/Testdata/result_get_entities.json
@@ -1,26 +1,37 @@
 {
-  "id": 3,
-  "type": "result",
-  "success": true,
-  "result": [
-    {
-      "config_entry_id": null,
-      "device_id": "42cdda32a2a3428e86c2e27699d79ead",
-      "disabled_by": null,
-      "entity_id": "media_player.tv_uppe2",
-      "area_id": "42cdda1212a3428e86c2e27699d79ead",
-      "name": null,
-      "icon": null,
-      "platform": "cast"
-    },
-    {
-      "config_entry_id": "4b85129c61c74b27bd90e593f6b7482e",
-      "device_id": "6e17380a6d2744d18045fe4f627db706",
-      "disabled_by": null,
-      "entity_id": "sensor.plex_plex",
-      "name": null,
-      "icon": null,
-      "platform": "plex"
-    }
-  ]
+    "id": 3,
+    "type": "result",
+    "success": true,
+    "result": [
+        {
+            "config_entry_id": null,
+            "device_id": "42cdda32a2a3428e86c2e27699d79ead",
+            "disabled_by": null,
+            "entity_id": "media_player.tv_uppe2",
+            "area_id": "42cdda1212a3428e86c2e27699d79ead",
+            "name": null,
+            "icon": null,
+            "platform": "cast",
+            "options": {
+                "conversation": {
+                    "should_expose": true
+                }
+            }
+
+        },
+        {
+            "config_entry_id": "4b85129c61c74b27bd90e593f6b7482e",
+            "device_id": "6e17380a6d2744d18045fe4f627db706",
+            "disabled_by": null,
+            "entity_id": "sensor.plex_plex",
+            "name": null,
+            "icon": null,
+            "platform": "plex",
+            "options": {
+                "conversation": {
+                    "should_expose": false
+                }
+            }
+        }
+    ]
 }

--- a/src/Client/NetDaemon.HassClient.Tests/Integration/WebsocketIntegrationTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/Integration/WebsocketIntegrationTests.cs
@@ -126,6 +126,19 @@ public class WebsocketIntegrationTests : IntegrationTestBase
         entities.Should().HaveCount(2);
     }
 
+
+    [Fact]
+    public async Task TestGetEntitiesShouldHaveConversationOptions()
+    {
+        await using var ctx = await GetConnectedClientContext().ConfigureAwait(false);
+        var entities = await ctx.HomeAssistantConnection
+            .GetEntitiesAsync(TokenSource.Token)
+            .ConfigureAwait(false);
+
+        bool? should_expose = entities?.ElementAt(0).Options?.Conversation?.ShouldExpose;
+        should_expose.Should().BeTrue();
+    }
+
     [Fact]
     public async Task TestGetConfigShouldReturnCorrectInformation()
     {

--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassConversationOptions.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassConversationOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace NetDaemon.Client.HomeAssistant.Model
+{
+    public record HassEntityConversationOptions
+    {
+        [JsonPropertyName("should_expose")] public bool ShouldExpose { get; init; }
+    }
+}

--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassEntity.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassEntity.cs
@@ -15,4 +15,7 @@ public record HassEntity
     [JsonPropertyName("platform")] public string? Platform { get; init; }
 
     [JsonPropertyName("labels")] public IReadOnlyList<string> Labels { get; init; } = [];
+	        
+    [JsonPropertyName("options")]public HassEntityOptions? Options { get; init; }
 }
+

--- a/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassEntityOptions.cs
+++ b/src/Client/NetDaemon.HassClient/Common/HomeAssistant/Model/HassEntityOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace NetDaemon.Client.HomeAssistant.Model
+{
+    public record HassEntityOptions
+    {
+        [JsonPropertyName("conversation")] public HassEntityConversationOptions? Conversation { get; init; }
+    }
+}

--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -120,6 +120,7 @@ internal static class HassObjectMapper
             Device = device,
             Labels = hassEntity.Labels.Select(registry.GetLabel).OfType<Label>().ToList(),
             Platform = hassEntity.Platform,
+            Options = new EntityOptions(hassEntity.Options)
         };
     }
 

--- a/src/HassModel/NetDeamon.HassModel/Registry/ConversationOptions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/ConversationOptions.cs
@@ -9,5 +9,20 @@
         /// If the entity should be available to voice/ai assistants
         /// </summary>
         public bool? ShouldExpose { get; init; }
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public ConversationOptions() { }
+
+        /// <summary>
+        /// Conversion from Websocket/API Model
+        /// </summary>
+        /// <param name="entityConversationOpts"></param>
+        public ConversationOptions(HassEntityConversationOptions entityConversationOpts)
+        {
+            ShouldExpose = entityConversationOpts.ShouldExpose;
+        }
     }
+
 }

--- a/src/HassModel/NetDeamon.HassModel/Registry/ConversationOptions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/ConversationOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace NetDaemon.HassModel.Entities
+{
+    /// <summary>
+    /// The options related to Assist/Conversation Assistants
+    /// </summary>
+    public record ConversationOptions
+    {
+        /// <summary>
+        /// If the entity should be available to voice/ai assistants
+        /// </summary>
+        public bool? ShouldExpose { get; init; }
+    }
+}

--- a/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
@@ -9,5 +9,23 @@ public record EntityOptions
     /// The Assist/Conversation options for a registration entity
     /// </summary>
     public ConversationOptions? ConversationOptions { get; init; }
+
+    /// <summary>
+    /// Default Constructor
+    /// </summary>
+    public EntityOptions() { }
+
+    /// <summary>
+    /// Conversion from Websocket/API Model
+    /// </summary>
+    /// <param name="entityOpts"></param>
+    public EntityOptions(HassEntityOptions? entityOpts)
+    {
+        if (entityOpts?.Conversation == null)
+            ConversationOptions = new ConversationOptions();
+        else
+            ConversationOptions = new ConversationOptions(entityOpts.Conversation);
+                
+    }
 }
 

--- a/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace NetDaemon.HassModel.Entities;
+
+/// <summary>
+/// Details of Options in the Home Assistant Registry
+/// </summary>
+public record EntityOptions
+{
+    /// <summary>
+    /// The Assist/Conversation options for a registration entity
+    /// </summary>
+    public ConversationOptions? ConversationOptions { get; init; }
+}
+

--- a/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/EntityOptions.cs
@@ -11,11 +11,6 @@ public record EntityOptions
     public ConversationOptions? ConversationOptions { get; init; }
 
     /// <summary>
-    /// Default Constructor
-    /// </summary>
-    public EntityOptions() { }
-
-    /// <summary>
     /// Conversion from Websocket/API Model
     /// </summary>
     /// <param name="entityOpts"></param>

--- a/src/HassModel/NetDeamon.HassModel/Registry/EntityRegistration.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/EntityRegistration.cs
@@ -34,4 +34,9 @@ public record EntityRegistration
     /// An identifier for the integration that created this Entity
     /// </summary>
     public string? Platform { get; init; }
+
+    /// <summary>
+    /// The options set for this Entity
+    /// </summary>
+	public EntityOptions? Options {get; init;}
 }


### PR DESCRIPTION
## Proposed change

This deserializes the `options` and `conversation` fields from the entity registry.  I have limited data there (only Assist, no Alexa/GA), so I started with the field that was most relevant to my needs, but could easily be expanded if someone wants to provide a sample containing Alexa/Google Assistant settings.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] The code compiles without warnings (code quality check)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for http://netdaemon.xtz
