### PR TITLE
Include NameByUser in HassModel

### DIFF
--- a/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
+++ b/src/HassModel/NetDeamon.HassModel/Internal/HassObjectMapper.cs
@@ -66,6 +66,7 @@ internal static class HassObjectMapper
         return new Device(registry)
         {
             Name = hassDevice.Name,
+            NameByUser = hassDevice.NameByUser,
             Id = hassDevice.Id ?? "Unavailable",
             Area = hassDevice.AreaId is null ? null : registry.GetArea(hassDevice.AreaId),
             Labels = hassDevice.Labels.Select(registry.GetLabel).OfType<Label>().ToList(),

--- a/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
+++ b/src/HassModel/NetDeamon.HassModel/Registry/Device.cs
@@ -18,6 +18,11 @@ public record Device
     public string? Name { get; init; }
 
     /// <summary>
+    /// The user-provided friendly name of the device
+    /// </summary>
+    public string? NameByUser { get; init; }
+
+    /// <summary>
     /// The Id of this Device
     /// </summary>
     public required string Id { get; init; }


### PR DESCRIPTION
This field (the user-provided friendly name, if it exists) was accidentally left off the HassModel API, so I've added it here.
