### PR TITLE
Use MSBuild to load projects, instead of manual parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ codecover_merged.info
 .idea/
 appsettings.[Dd]evelopment.json
 
+# Don't track msbuildlogs that may be created locally for investigations
+*.binlog
+
 # remove HA integration test files from git
 tests/Integration/HA/config/*
 !tests/Integration/HA/config/*.yaml

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/NetDaemon.HassModel.CodeGenerator.csproj
@@ -23,6 +23,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Build" Version="17.13.9" ExcludeAssets="runtime"/>
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Microsoft.Build.Locator;
 using Microsoft.Extensions.Configuration;
 using NetDaemon.Client.Settings;
 
@@ -17,6 +18,7 @@ if (args.Any(arg => arg.ToLower(CultureInfo.InvariantCulture) == "-help"))
 //This is used as a command line switch rather than a configuration key. There is no key value following it to interpret.
 generationSettings.GenerateOneFilePerEntity = args.Any(arg => arg.ToLower(CultureInfo.InvariantCulture) == "-fpe");
 
+MSBuildLocator.RegisterDefaults();
 VersionHelper.PrintVersion();
 await VersionValidator.ValidateLatestVersion();
 VersionValidator.ValidatePackageReferences();

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/DependencyValidatorTests.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/DependencyValidatorTests.cs
@@ -1,9 +1,17 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Locator;
 using NetDaemon.HassModel.CodeGenerator;
 
 namespace NetDaemon.HassModel.Tests.CodeGenerator;
 
 public class DependencyValidatorTests
 {
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        MSBuildLocator.RegisterDefaults();
+    }
+
     // Test that pre-release versions are trimmed using the TrimPreReleaseVersion method using theory
     [Theory]
     [InlineData("1.0.0-alpha", "1.0.0")]
@@ -18,5 +26,22 @@ public class DependencyValidatorTests
 
         // ASSERT
         result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(@"CodeGenerator\TestFiles\RawVersions\RawVersions.csproj")]
+    [InlineData(@"CodeGenerator\TestFiles\SubstitutedVersions\SubstitutedVersions.csproj")]
+    public void ValidateProjectFileParsed(string projectFile)
+    {
+        VersionValidator.GetPackageReferences(projectFile)
+            .Should().BeEquivalentTo([
+                ("NetDaemon.AppModel", "25.6.0"),
+                ("NetDaemon.Runtime", "25.6.0"),
+                ("NetDaemon.HassModel", "25.6.0"),
+                ("NetDaemon.Client", "25.6.0"),
+                ("NetDaemon.Extensions.Scheduling", "25.6.0"),
+                ("NetDaemon.Extensions.Logging", "25.6.0"),
+                ("NetDaemon.Extensions.Tts", "25.6.0")
+            ]);
     }
 }

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/TestFiles/RawVersions/RawVersions.csproj
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/TestFiles/RawVersions/RawVersions.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetDaemon.AppModel" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.Runtime" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.HassModel" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.Client" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.Extensions.Logging" Version="25.6.0" />
+    <PackageReference Include="NetDaemon.Extensions.Tts" Version="25.6.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/TestFiles/SubstitutedVersions/SubstitutedVersions.csproj
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/TestFiles/SubstitutedVersions/SubstitutedVersions.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NetDaemonVersion>25.6.0</NetDaemonVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetDaemon.AppModel" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.Runtime" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.HassModel" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.Client" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.Extensions.Logging" Version="$(NetDaemonVersion)" />
+    <PackageReference Include="NetDaemon.Extensions.Tts" Version="$(NetDaemonVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/HassModel/NetDaemon.HassModel.Tests/NetDaemon.HassModel.Tests.csproj
+++ b/src/HassModel/NetDaemon.HassModel.Tests/NetDaemon.HassModel.Tests.csproj
@@ -37,6 +37,10 @@
     <None Update="CodeGenerator\ServiceMetaDataSamples\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Compile Remove="CodeGenerator\TestFiles\**" />
+    <None Include="CodeGenerator\TestFiles\**\*.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
For users (like me) who use a property to specify all their netdaemon versions, instead of individual versions, the existing checks are too simple. I've updated it to instead use msbuild to actually load the project file and determine the real version that nuget will see.
