### PR TITLE
fix #1288 Codegen parameter name conflict when a field is called 'tar…

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServiceArguments.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServiceArguments.cs
@@ -26,14 +26,9 @@ internal class ServiceArguments
     private readonly string _serviceName;
     private readonly string _domain;
 
-    public static ServiceArguments? Create(string domain, HassService service)
+    public static ServiceArguments Create(string domain, HassService service)
     {
-        if (service.Fields is null || service.Fields.Count == 0)
-        {
-            return null;
-        }
-
-        return new ServiceArguments(domain, service.Service, service.Fields);
+        return new ServiceArguments(domain, service.Service, service.Fields ?? []);
     }
 
     private ServiceArguments(string domain, string serviceName, IReadOnlyCollection<HassServiceField> serviceFields)
@@ -61,6 +56,23 @@ internal class ServiceArguments
         var propertyInitializers = Arguments.Select(x => $"{x.PropertyName} = {EscapeIfRequired(x.ParameterName)}");
 
         return $"new {TypeName} {{  { string.Join(", ", propertyInitializers) }  }}";
+    }
+
+    public string ServiceTargetParameterName
+    {
+        get
+        {
+            const string baseName = "target";
+
+            if (Arguments.Any(a => a.ParameterName == baseName))
+            {
+                // Append an _ to the base name to avoid name collision
+                // in normal fields the _ is removed so it cannot clash
+                return '_' + baseName;
+            }
+
+            return baseName;
+        }
     }
 
     /// <summary>

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -66,7 +66,7 @@ internal static class ServicesGenerator
     {
         var serviceArguments = ServiceArguments.Create(domain, service);
 
-        if (serviceArguments is null)
+        if (!serviceArguments.Arguments.Any())
         {
             yield break;
         }
@@ -91,11 +91,11 @@ internal static class ServicesGenerator
 
         var serviceMethodName = GetServiceMethodName(serviceName);
 
-        var targetParam = service.Target is not null ? $"{SimplifyTypeName(typeof(ServiceTarget))} target" : null;
-        var targetArg = service.Target is not null ? "target" : "null";
-        var targetComment = service.Target is not null ? ParameterComment("target", "The target for this service call") : (SyntaxTrivia?)null;
+        var targetParam = service.Target is not null ? $"{SimplifyTypeName(typeof(ServiceTarget))} {serviceArguments.ServiceTargetParameterName}" : null;
+        var targetArg = service.Target is not null ? serviceArguments.ServiceTargetParameterName : "null";
+        var targetComment = service.Target is not null ? ParameterComment(serviceArguments.ServiceTargetParameterName, "The target for this service call") : (SyntaxTrivia?)null;
 
-        if (serviceArguments is null)
+        if (!serviceArguments.Arguments.Any())
         {
             // method without arguments
             foreach (var method in GenerateServiceMethodWithoutArguments(serviceMethodName, targetParam, targetComment, targetArg, domain, serviceName, haContextVariableName, service))


### PR DESCRIPTION
…get'

<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #1288 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for https://netdaemon.xyz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
