### PR TITLE
Replaced depricated set-output function in two workflows.

### DIFF
--- a/.github/workflows/tags_docker.yml
+++ b/.github/workflows/tags_docker.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           latest=$(git describe --tags $(git rev-list --tags --max-count=1))
           echo Current version:    $latest
-          echo "::set-output name=version::$latest"
+          echo "version=$latest" >> $GITHUB_OUTPUT
 
       - name: 📆 Set version number
         run: |
@@ -79,7 +79,7 @@ jobs:
         run: |
           latest=$(git describe --tags $(git rev-list --tags --max-count=1))
           echo Current version:    $latest
-          echo "::set-output name=version::$latest"
+          echo "version=$latest" >> $GITHUB_OUTPUT
 
       - name: 📆 Set version number
         run: |

--- a/.github/workflows/tags_nuget.yml
+++ b/.github/workflows/tags_nuget.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           latest=$(git describe --tags $(git rev-list --tags --max-count=1))
           echo Current version:    $latest
-          echo "::set-output name=version::$latest"
+          echo "version=$latest" >> $GITHUB_OUTPUT
 
       - name: 🥅 Install .Net 9
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Proposed change
Replaced depricated set-output function in two workflows.


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
The function set-output is depricated.
Check the annotations of this workflow run: https://github.com/net-daemon/netdaemon/actions/runs/14943317538
More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist
- [ ] The code change is tested and works locally. **-> I did test this on a repos of my own. Works.**
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [ ] Tests have been added to verify that the new code works.