### PR TITLE
fix: handle non-mapping YAML root in YamlConfigurationFileParser

### DIFF
--- a/src/AppModel/NetDaemon.AppModel.Tests/Config/ConfigTests.cs
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Config/ConfigTests.cs
@@ -53,6 +53,50 @@ public class ConfigTests
         Assert.Throws<InvalidDataException>(() => configurationBuilder.Build());
     }
 
+    // Regression: a YAML file whose ROOT is not a mapping must not crash config-build.
+    // Home Assistant !include targets such as automations.yaml hold a sequence root ("[]"),
+    // and a bare value is a scalar root. The parser previously cast the root unconditionally
+    // to YamlMappingNode and threw InvalidCastException at host-config time, before the host
+    // (and any logging) started. A non-mapping root carries no key/value config, so it must
+    // contribute no data instead.
+    [Theory]
+    [InlineData("[]")]                 // sequence root (the automations.yaml case)
+    [InlineData("- one\n- two")]       // sequence root with items
+    [InlineData("just-a-scalar")]      // scalar root
+    public void NonMappingRootedYaml_ContributesNoData_InsteadOfThrowing(string yamlContent)
+    {
+        BuildYamlFileAndAssertNoData(yamlContent);
+    }
+
+    // Regression: an empty YAML file (no documents) likewise contributes no data.
+    [Fact]
+    public void EmptyYaml_ContributesNoData_InsteadOfThrowing()
+    {
+        BuildYamlFileAndAssertNoData(string.Empty);
+    }
+
+    private static void BuildYamlFileAndAssertNoData(string yamlContent)
+    {
+        // ARRANGE
+        var yamlPath = Path.Combine(Path.GetTempPath(), $"nd-yaml-root-{Guid.NewGuid():N}.yaml");
+        File.WriteAllText(yamlPath, yamlContent);
+        try
+        {
+            var configurationBuilder = new ConfigurationBuilder() as IConfigurationBuilder;
+            configurationBuilder.AddYamlFile(yamlPath, false, false);
+
+            // ACT
+            var root = configurationBuilder.Build();
+
+            // CHECK
+            root.AsEnumerable().Should().BeEmpty();
+        }
+        finally
+        {
+            File.Delete(yamlPath);
+        }
+    }
+
     [Fact]
     public void TestAppGetCorrectJsonConfigInjected()
     {

--- a/src/AppModel/NetDaemon.AppModel/Internal/Config/Yaml/YamlConfigurationFileParser.cs
+++ b/src/AppModel/NetDaemon.AppModel/Internal/Config/Yaml/YamlConfigurationFileParser.cs
@@ -27,9 +27,13 @@ internal class YamlConfigurationFileParser
         yaml.Load(new StreamReader(input, true));
 
         if (yaml.Documents.Count == 0) return _data;
-        var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
 
-        // The document node is a mapping node
+        // The configuration model is key/value pairs, so only a mapping root carries config data.
+        // Home Assistant !include targets such as automations.yaml have a sequence root ("[]") or
+        // may be empty (scalar/null). Those hold no key/value config, so treat them as no data
+        // rather than casting and throwing InvalidCastException at host-config time.
+        if (yaml.Documents[0].RootNode is not YamlMappingNode mapping) return _data;
+
         VisitYamlMappingNode(mapping);
 
         return _data;


### PR DESCRIPTION
## Summary

The host crashes at config-build time when an app-config folder contains a YAML file whose root is not a mapping.

I hit this running a real config: a Home Assistant `!include` target like `automations.yaml` whose content is a sequence root (`[]`) gets picked up by `AddYamlAppConfig`, and the parser casts the root unconditionally to a mapping. That throws `InvalidCastException` from inside `HostBuilder.Build()`, before the host (and any logging) is up, so the failure is opaque.

## Repro

An app-config directory containing a YAML file with a sequence root:

```yaml
# automations.yaml
[]
```

`AddYamlAppConfig` feeds it through `YamlConfigurationFileParser`, and `(YamlMappingNode)RootNode` throws during `HostBuilder.Build()`.

## Root cause

The parser guards only the zero-document case, then casts any root unconditionally to `YamlMappingNode`. A sequence root or a scalar root is a valid YAML document, so the cast throws instead of being handled.

## Fix

A pattern-match guard. The configuration model is key/value pairs, so only a mapping root carries config data. A non-mapping root carries no key/value config, so it contributes nothing instead of throwing. This mirrors the existing empty-file guard right above it.

```csharp
if (yaml.Documents[0].RootNode is not YamlMappingNode mapping) return _data;
```

## Tests

Added regression cases to `ConfigTests`:

- sequence root (`[]`) — the `automations.yaml` case
- sequence root with items
- scalar root
- empty file

Each asserts the built configuration contributes no data instead of throwing.

## Notes

Found by running a real config, not synthetically. Frank asked for the fix to be sent upstream.

I couldn't apply the `pr: bugfix` label from a fork — a maintainer may want to add it.
