### PR TITLE
Stabilize result message handler tests

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/HelperTest/ResultMessageHandlerTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HelperTest/ResultMessageHandlerTests.cs
@@ -107,7 +107,7 @@ public sealed class ResultMessageHandlerTests : IAsyncLifetime, IAsyncDisposable
     async Task FlushMessageHandler()
     {
         await _resultMessageHandler.WaitPendingBackgroundTasksAsync()
-            .WaitAsync(TimeSpan.FromMilliseconds(100)) // avoid blocking the test in case something is wrong
+            .WaitAsync(TimeSpan.FromSeconds(5)) // avoid blocking the test in case something is wrong
             .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary
- Increase the ResultMessageHandlerTests flush guard from 100 ms to 5 seconds so CI has realistic headroom to schedule the background logging task.
- Keeps a timeout in place so genuine hangs still fail the test.

## Verification
- dotnet test src/Client/NetDaemon.HassClient.Tests/NetDaemon.HassClient.Tests.csproj --configuration Debug --filter FullyQualifiedName~ResultMessageHandlerTests --logger "console;verbosity=minimal"
- dotnet test src/Client/NetDaemon.HassClient.Tests/NetDaemon.HassClient.Tests.csproj --no-restore --configuration Release --filter FullyQualifiedName~ResultMessageHandlerTests --logger "console;verbosity=minimal"