### PR TITLE
Add ICurrentApp to expose the current app id to apps

### DIFF
--- a/src/AppModel/NetDaemon.AppModel.Tests/Context/ApplicationContextTests.cs
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Context/ApplicationContextTests.cs
@@ -15,4 +15,16 @@ public class ApplicationContextTests
         await applicationContext.DisposeAsync();
         await applicationContext.DisposeAsync();
     }
+
+    [Fact]
+    public void TestApplicationContextExposesAppFactoryIdAsCurrentApp()
+    {
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var appFactory = new Mock<IAppFactory>();
+        appFactory.SetupGet(f => f.Id).Returns("MyApps.SomeApp");
+
+        ICurrentApp currentApp = new ApplicationContext(serviceProvider, appFactory.Object);
+
+        currentApp.Id.Should().Be("MyApps.SomeApp");
+    }
 }

--- a/src/AppModel/NetDaemon.AppModel.Tests/Context/CurrentAppTests.cs
+++ b/src/AppModel/NetDaemon.AppModel.Tests/Context/CurrentAppTests.cs
@@ -1,0 +1,36 @@
+using NetDaemon.AppModel.Internal;
+
+namespace NetDaemon.AppModel.Tests.Context;
+
+public class CurrentAppTests
+{
+    [Fact]
+    public async Task AppCanInjectCurrentAppAndGetsItsOwnId()
+    {
+        // ARRANGE
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddNetDaemonApp<AppThatCapturesItsId>();
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var appModelContext = serviceProvider.GetRequiredService<IAppModelContext>();
+
+        // ACT
+        await appModelContext.InitializeAsync(CancellationToken.None);
+
+        // ASSERT
+        var application = (Application)appModelContext.Applications.Single();
+        var instance = (AppThatCapturesItsId)application.ApplicationContext!.Instance!;
+        instance.CapturedId.Should().Be(typeof(AppThatCapturesItsId).FullName);
+    }
+
+    private sealed class AppThatCapturesItsId
+    {
+        public AppThatCapturesItsId(ICurrentApp currentApp)
+        {
+            CapturedId = currentApp.Id;
+        }
+
+        public string CapturedId { get; }
+    }
+}

--- a/src/AppModel/NetDaemon.AppModel/Common/Extensions/ServiceCollectionExtension.cs
+++ b/src/AppModel/NetDaemon.AppModel/Common/Extensions/ServiceCollectionExtension.cs
@@ -111,7 +111,8 @@ public static class ServiceCollectionExtensions
     {
         services
             .AddScoped<ApplicationScope>()
-            .AddScoped(s => s.GetRequiredService<ApplicationScope>().ApplicationContext);
+            .AddScoped(s => s.GetRequiredService<ApplicationScope>().ApplicationContext)
+            .AddScoped<ICurrentApp>(s => s.GetRequiredService<ApplicationContext>());
         return services;
     }
 

--- a/src/AppModel/NetDaemon.AppModel/Common/ICurrentApp.cs
+++ b/src/AppModel/NetDaemon.AppModel/Common/ICurrentApp.cs
@@ -1,0 +1,19 @@
+namespace NetDaemon.AppModel;
+
+/// <summary>
+///     Provides information about the app that owns the current dependency injection scope.
+/// </summary>
+/// <remarks>
+///     Resolve this from an app's constructor, or from any service registered in the app's
+///     scope, to discover which app is being instantiated - for example to select per-app
+///     configuration or logging.
+/// </remarks>
+public interface ICurrentApp
+{
+    /// <summary>
+    ///     Gets the unique id of the app that owns the current scope. This is the same id
+    ///     NetDaemon uses elsewhere: the value of <see cref="NetDaemonAppAttribute.Id"/> when
+    ///     set, otherwise the full name of the app type.
+    /// </summary>
+    string Id { get; }
+}

--- a/src/AppModel/NetDaemon.AppModel/Internal/Context/ApplicationContext.cs
+++ b/src/AppModel/NetDaemon.AppModel/Internal/Context/ApplicationContext.cs
@@ -2,7 +2,7 @@ using NetDaemon.AppModel.Internal.AppFactories;
 
 namespace NetDaemon.AppModel.Internal;
 
-internal sealed class ApplicationContext : IAsyncDisposable
+internal sealed class ApplicationContext : IAsyncDisposable, ICurrentApp
 {
     private readonly CancellationTokenSource _cancelTokenSource = new();
     private readonly IServiceScope? _serviceScope;
@@ -21,8 +21,12 @@ internal sealed class ApplicationContext : IAsyncDisposable
         if (appScope != null) appScope.ApplicationContext = this;
 
         // Now create the actual app from the new scope
+        Id = appFactory.Id;
         Instance = appFactory.Create(scopedProvider);
     }
+
+    /// <inheritdoc />
+    public string Id { get; }
 
     public object? Instance { get; private set; }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apps and services resolved in an app's DI scope had no supported way to find out which app they belong to. The only object carrying that information, ApplicationContext, is internal.

Add a small read-only ICurrentApp interface exposing the app id, and register the existing scoped ApplicationContext as its implementation. This lets an app inject ICurrentApp (or resolve it from any service in its scope) to select per-app configuration, logging, etc. IApplication is not reused for this because it also exposes lifecycle methods that apps should not call on themselves.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [x] Documentation added/updated for https://netdaemon.xyz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
