### PR TITLE
Fix inverted app enable/disable state write

### DIFF
--- a/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
+++ b/src/Runtime/NetDaemon.Runtime.Tests/Internal/AppStateManagerTests.cs
@@ -82,10 +82,10 @@ public class AppStateManagerTests
         // ASSERT
         haConnectionMock.Verify(n =>
             n.GetApiCallAsync<HassState>("states/input_boolean.netdaemon_helloapp", It.IsAny<CancellationToken>()));
-        // It exists so it should turn it on
+        // It is on so it should turn it off
         haConnectionMock.Verify(n =>
-            n.SendCommandAsync(It.IsAny<CallServiceCommand>(),
-                It.IsAny<CancellationToken>()));
+            n.SendCommandAsync(It.Is<CallServiceCommand>(c => c.Domain == "input_boolean" && c.Service == "turn_off"),
+                It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -156,10 +156,10 @@ public class AppStateManagerTests
         // ASSERT
         haConnectionMock.Verify(n =>
             n.GetApiCallAsync<HassState>("states/input_boolean.netdaemon_helloapp", It.IsAny<CancellationToken>()));
-        // It exists so it should turn it on
+        // It is off so it should turn it on
         haConnectionMock.Verify(n =>
-            n.SendCommandAsync(It.IsAny<CallServiceCommand>(),
-                It.IsAny<CancellationToken>()));
+            n.SendCommandAsync(It.Is<CallServiceCommand>(c => c.Domain == "input_boolean" && c.Service == "turn_on"),
+                It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
+++ b/src/Runtime/NetDaemon.Runtime/Internal/AppStateManager.cs
@@ -69,7 +69,7 @@ internal class AppStateManager(IAppStateRepository appStateRepository,
             (state == ApplicationState.Disabled && isEnabled)
             )
         {
-            await appStateRepository.UpdateAsync(applicationId, isEnabled, _cancelTokenSource.Token)
+            await appStateRepository.UpdateAsync(applicationId, state == ApplicationState.Enabled, _cancelTokenSource.Token)
                 .ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`AppStateManager.SaveStateAsync` only calls `IAppStateRepository.UpdateAsync` when the requested `ApplicationState` differs from the current `input_boolean` state, but it passed the *current* `isEnabled` value instead of the desired one. As a result every real write did the opposite of what was requested:

- `SaveStateAsync(id, Enabled)` while the helper is `off` sent `input_boolean.turn_off`
- `SaveStateAsync(id, Disabled)` while the helper is `on` sent `input_boolean.turn_on`

This PR passes `state == ApplicationState.Enabled` to `UpdateAsync` so the helper is set to the desired state.

The existing `AppStateManagerTests` only verified that *some* `call_service` command was sent, which is why this slipped through. The two affected tests now assert the exact domain and service (`input_boolean.turn_off` / `input_boolean.turn_on`) and that it is sent exactly once. Both tests fail against the previous code and pass with the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

Found during a code review of the runtime; no issue was filed for it. The bug only affects users who opt in via `AddNetDaemonStateManager()`.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for https://netdaemon.xyz


<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/