### PR TITLE
Unwrap the connection message pump task

### DIFF
--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
@@ -361,12 +361,14 @@ public class HomeAssistantConnectionTests
     public async Task DisposingConnectionShouldWaitForMessagePumpBeforeDisposingPipeline()
     {
         var pipeline = new TransportPipelineMock();
+        var receiveStarted = new TaskCompletionSource();
         var messagePumpStopped = false;
         var messagePumpStoppedWhenPipelineDisposed = false;
         pipeline
             .Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>()))
             .Returns<CancellationToken>(async cancelToken =>
             {
+                receiveStarted.TrySetResult();
                 var cancelled = new TaskCompletionSource();
                 await using var registration = cancelToken.Register(() => cancelled.TrySetResult());
                 await cancelled.Task.ConfigureAwait(false);
@@ -381,6 +383,8 @@ public class HomeAssistantConnectionTests
             .Returns(ValueTask.CompletedTask);
 
         var homeAssistantConnection = CreateHomeAssistantConnection(pipeline);
+        // The pump starts on its own thread, so make sure it is inside the receive before shutting down
+        await receiveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await homeAssistantConnection.DisposeAsync();
 
@@ -417,13 +421,16 @@ public class HomeAssistantConnectionTests
     {
         var pipeline = new TransportPipelineMock();
         var loggerMock = new Mock<ILogger<IHomeAssistantConnection>>();
+        var receiveStarted = new TaskCompletionSource();
         var socketClosed = new TaskCompletionSource();
+        var transportException = new ApplicationException("Cannot send data on a closed socket!");
         pipeline
             .Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>()))
             .Returns<CancellationToken>(async _ =>
             {
+                receiveStarted.TrySetResult();
                 await socketClosed.Task.ConfigureAwait(false);
-                throw new ApplicationException("Cannot send data on a closed socket!");
+                throw transportException;
             });
         pipeline
             .Setup(n => n.CloseAsync())
@@ -431,9 +438,19 @@ public class HomeAssistantConnectionTests
             .Returns(Task.CompletedTask);
 
         var homeAssistantConnection = CreateHomeAssistantConnection(pipeline, loggerMock: loggerMock);
+        // The pump starts on its own thread, so make sure it is inside the receive before shutting down
+        await receiveStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await homeAssistantConnection.DisposeAsync();
 
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString() == "Message pump stopped while disposing the Home Assistant connection"),
+                transportException,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
         loggerMock.Verify(
             x => x.Log(
                 LogLevel.Error,

--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
@@ -14,11 +14,12 @@ public class HomeAssistantConnectionTests
 
     private static HomeAssistantConnection CreateHomeAssistantConnection(TransportPipelineMock pipeline,
         TimeProvider? timeProvider = null,
-        TimeSpan? waitForResultTimeout = null)
+        TimeSpan? waitForResultTimeout = null,
+        Mock<ILogger<IHomeAssistantConnection>>? loggerMock = null)
     {
         pipeline.Setup(n => n.WebSocketState).Returns(WebSocketState.Open);
         var apiManagerMock = new Mock<IHomeAssistantApiManager>();
-        var loggerMock = new Mock<ILogger<IHomeAssistantConnection>>();
+        loggerMock ??= new Mock<ILogger<IHomeAssistantConnection>>();
         return new HomeAssistantConnection(loggerMock.Object, pipeline.Object, apiManagerMock.Object,
             timeProvider, waitForResultTimeout);
     }
@@ -384,5 +385,62 @@ public class HomeAssistantConnectionTests
         await homeAssistantConnection.DisposeAsync();
 
         messagePumpStoppedWhenPipelineDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MessagePumpFailureShouldBeLoggedAsErrorAndCloseConnection()
+    {
+        var pipeline = new TransportPipelineMock();
+        var loggerMock = new Mock<ILogger<IHomeAssistantConnection>>();
+        var transportException = new ApplicationException("transport failed");
+        pipeline
+            .Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>()))
+            .Throws(transportException);
+
+        await using var homeAssistantConnection = CreateHomeAssistantConnection(pipeline, loggerMock: loggerMock);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => homeAssistantConnection.WaitForConnectionToCloseAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5)));
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString() == "Message pump stopped unexpectedly, closing the Home Assistant connection"),
+                transportException,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MessagePumpFailureWhileDisposingShouldNotBeLoggedAsError()
+    {
+        var pipeline = new TransportPipelineMock();
+        var loggerMock = new Mock<ILogger<IHomeAssistantConnection>>();
+        var socketClosed = new TaskCompletionSource();
+        pipeline
+            .Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async _ =>
+            {
+                await socketClosed.Task.ConfigureAwait(false);
+                throw new ApplicationException("Cannot send data on a closed socket!");
+            });
+        pipeline
+            .Setup(n => n.CloseAsync())
+            .Callback(() => socketClosed.TrySetResult())
+            .Returns(Task.CompletedTask);
+
+        var homeAssistantConnection = CreateHomeAssistantConnection(pipeline, loggerMock: loggerMock);
+
+        await homeAssistantConnection.DisposeAsync();
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
     }
 }

--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/HomeAssistantConnectionTests.cs
@@ -355,4 +355,34 @@ public class HomeAssistantConnectionTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => resultTask.WaitAsync(TimeSpan.FromSeconds(5)));
     }
+
+    [Fact]
+    public async Task DisposingConnectionShouldWaitForMessagePumpBeforeDisposingPipeline()
+    {
+        var pipeline = new TransportPipelineMock();
+        var messagePumpStopped = false;
+        var messagePumpStoppedWhenPipelineDisposed = false;
+        pipeline
+            .Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async cancelToken =>
+            {
+                var cancelled = new TaskCompletionSource();
+                await using var registration = cancelToken.Register(() => cancelled.TrySetResult());
+                await cancelled.Task.ConfigureAwait(false);
+                // Simulate the transport taking a moment to finish its receive after cancellation
+                await Task.Delay(200, CancellationToken.None).ConfigureAwait(false);
+                messagePumpStopped = true;
+                throw new OperationCanceledException(cancelToken);
+            });
+        pipeline
+            .Setup(n => n.DisposeAsync())
+            .Callback(() => messagePumpStoppedWhenPipelineDisposed = messagePumpStopped)
+            .Returns(ValueTask.CompletedTask);
+
+        var homeAssistantConnection = CreateHomeAssistantConnection(pipeline);
+
+        await homeAssistantConnection.DisposeAsync();
+
+        messagePumpStoppedWhenPipelineDisposed.Should().BeTrue();
+    }
 }

--- a/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/TransportPipelineMock.cs
+++ b/src/Client/NetDaemon.HassClient.Tests/HomeAssistantClientTest/TransportPipelineMock.cs
@@ -8,18 +8,16 @@ internal sealed class TransportPipelineMock : Mock<IWebSocketClientTransportPipe
     public TransportPipelineMock()
     {
         Setup(n => n.GetNextMessagesAsync<HassMessage>(It.IsAny<CancellationToken>())).Returns(
-            async (CancellationToken _) =>
+            async (CancellationToken cancelToken) =>
             {
-
-                var msg = await _responseMessageChannel.Reader.ReadAsync(CancellationToken.None).ConfigureAwait(false);
+                var msg = await _responseMessageChannel.Reader.ReadAsync(cancelToken).ConfigureAwait(false);
                 return [msg];
             });
 
         Setup(n => n.GetNextMessagesAsync<HassAuthResponse>(It.IsAny<CancellationToken>())).Returns(
-            async (CancellationToken _) =>
+            async (CancellationToken cancelToken) =>
             {
-
-                var msg = await _authResponseMessageChannel.Reader.ReadAsync(CancellationToken.None).ConfigureAwait(false);
+                var msg = await _authResponseMessageChannel.Reader.ReadAsync(cancelToken).ConfigureAwait(false);
                 return [msg];
             });
     }

--- a/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
@@ -62,7 +62,7 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
                 $"Expected WebSocket state 'Open' got '{_transportPipeline.WebSocketState}'");
 
         _handleNewMessagesTask = Task.Factory.StartNew(async () => await HandleNewMessages().ConfigureAwait(false),
-            TaskCreationOptions.LongRunning);
+            TaskCreationOptions.LongRunning).Unwrap();
     }
 
     public async Task<IObservable<HassEvent>> SubscribeToHomeAssistantEventsAsync(string? eventType,

--- a/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
+++ b/src/Client/NetDaemon.HassClient/Internal/HomeAssistantConnection.cs
@@ -251,6 +251,14 @@ internal class HomeAssistantConnection : IHomeAssistantConnection, IHomeAssistan
         {
             // Normal case just exit
         }
+        catch (Exception e)
+        {
+            // Disposing closes the socket before cancelling the pump, so a failing receive is expected then
+            if (_isDisposed)
+                _logger.LogDebug(e, "Message pump stopped while disposing the Home Assistant connection");
+            else
+                _logger.LogError(e, "Message pump stopped unexpectedly, closing the Home Assistant connection");
+        }
         finally
         {
             _logger.LogTrace("Stop processing new messages");


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to NetDaemon. 🎉
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If the PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards the users, not the devs.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Two related defects in the `HomeAssistantConnection` message pump (`HandleNewMessages`).

**The pump task was never unwrapped.** The pump is started with `Task.Factory.StartNew(async () => await HandleNewMessages())` but `.Unwrap()` was never called. The stored `_handleNewMessagesTask` was therefore the outer `Task<Task>`, which completes as soon as the lambda hits its first `await`. As a result `DisposeAsync` never actually waited for the pump. It went straight on to dispose the transport pipeline, the internal `CancellationTokenSource` and the message `Subject` while `HandleNewMessages` could still be in the middle of a receive or dispatching messages.

**Non-cancellation failures in the pump were swallowed silently.** `HandleNewMessages` only caught `OperationCanceledException`. A transport failure such as an `ApplicationException` or `JsonException` from `GetNextMessagesAsync` escaped the loop; the `finally` block still closed the connection and the runner reconnected, but nothing was ever logged, so a dropped connection left no trace of why.

This PR:

- Adds `.Unwrap()` so `_handleNewMessagesTask` represents the real pump. `DisposeAsync` now waits for it to exit (still bounded by the existing 5 s `WhenAny` timeout) before tearing down the pipeline and other resources.
- Catches the remaining exceptions in `HandleNewMessages` and logs them at `Error` with the original exception. When the connection is already being disposed the failure is expected, because `DisposeAsync` closes the socket before cancelling the pump, so in that case it is logged at `Debug` instead.
- Makes `TransportPipelineMock` honour the cancellation token passed to `GetNextMessagesAsync`. It previously read from its channel with `CancellationToken.None`, which would have made every test that disposes a connection wait out the full 5 s now that disposal genuinely waits for the pump.
- Adds tests:
  - `DisposingConnectionShouldWaitForMessagePumpBeforeDisposingPipeline` simulates a transport that lingers briefly after cancellation and asserts the pump has exited by the time the pipeline is disposed. Fails without the `.Unwrap()` change.
  - `MessagePumpFailureShouldBeLoggedAsErrorAndCloseConnection` asserts a throwing transport is logged at `Error` with the original exception and that the connection closes. Fails without the new catch.
  - `MessagePumpFailureWhileDisposingShouldNotBeLoggedAsError` asserts a transport failure during disposal is never logged at `Error`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for https://netdaemon.xyz

[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
