### PR TITLE
Skip service domains without services in the code generator

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/Generator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/Generator.cs
@@ -13,7 +13,9 @@ internal static class Generator
         IReadOnlyCollection<EntityDomainMetadata> entityDomains,
         IReadOnlyCollection<HassServiceDomain> services)
     {
-        var orderedServiceDomains = services.OrderBy(x => x.Domain).ToArray();
+        // Domains whose services all failed to parse have no services class, so they must not be
+        // referenced from IServices, Services or the DI registrations either
+        var orderedServiceDomains = services.Where(x => x.Services.Any()).OrderBy(x => x.Domain).ToArray();
 
         var helpers = HelpersGenerator.Generate(entityDomains, orderedServiceDomains);
         var entityFactory = EntityFactoryGenerator.Generate(entityDomains);

--- a/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
+++ b/src/HassModel/NetDaemon.HassModel.CodeGenerator/CodeGeneration/ServicesGenerator.cs
@@ -13,7 +13,7 @@ internal static class ServicesGenerator
 
         yield return GenerateRootServicesType(domains);
 
-        foreach (var domainServicesGroup in serviceDomains.Where(sd => sd.Services.Any()).GroupBy(x => x.Domain, x => x.Services))
+        foreach (var domainServicesGroup in serviceDomains.GroupBy(x => x.Domain, x => x.Services))
         {
             var domain = domainServicesGroup.Key!;
             var domainServices = domainServicesGroup

--- a/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServicesGeneratorTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/CodeGenerator/ServicesGeneratorTest.cs
@@ -536,6 +536,48 @@ public class ServicesGeneratorTest
         CodeGenTestHelper.AssertCodeCompiles(code.ToString(), appCode);
     }
 
+    [Fact]
+    public void TestDomainWithoutAnyServices_ServicesTypeNotReferenced()
+    {
+        var readOnlyCollection = new HassState[] {
+            new() { EntityId = "light.light1" },
+        };
+
+        // A domain ends up without services when ServiceMetaDataParser drops all of its services
+        // because they failed to deserialize
+        var hassServiceDomains = new HassServiceDomain[] {
+            new() {
+                Domain = "broken_domain",
+                Services = [],
+            },
+            new() {
+                Domain = "light",
+                Services = [
+                    new() {
+                        Service = "turn_on",
+                        Target = new TargetSelector
+                        {
+                            Entity = [new EntitySelector { Domain = ["light"] }]
+                        }
+                    }
+                ]
+            }
+        };
+
+        // Act:
+        var code = CodeGenTestHelper.GenerateCompilationUnit(_settings, readOnlyCollection, hassServiceDomains);
+
+        code.ToString().Should().NotContain("BrokenDomainServices",
+            because: "a domain without services has no services class, so nothing may reference it");
+
+        var appCode = WrapMethodBody(
+            """
+                services.Light.TurnOn(new ServiceTarget());
+            """);
+
+        CodeGenTestHelper.AssertCodeCompiles(code.ToString(), appCode);
+    }
+
     private static string WrapMethodBody([StringSyntax("C#")]string methodBody)
     {
         var appCode = $$"""


### PR DESCRIPTION
## Proposed change

`nd-codegen` could emit a `HomeAssistantGenerated.cs` that does not compile.

`Generator.GenerateTypes` handed every service domain to `HelpersGenerator` and `ServicesGenerator`. `ServicesGenerator` only emitted a `{Domain}Services` class for domains that still had at least one service, but it built the `IServices` interface and the `Services` root class from *all* domains, and `HelpersGenerator` registered `AddTransient<{Domain}Services>()` for all domains as well.

`ServiceMetaDataParser` swallows per-service deserialization errors by design. When every service of a domain fails to parse, that domain reaches the generators with an empty service list. The generated file then contained an `IServices` property, a `Services` property and a DI registration for a `{Domain}Services` type that was never declared, so the user's project no longer built.

This PR:

- Filters out domains without services once, in `Generator.GenerateTypes`, before the helpers, services and extension-method generators see them. All generated types now agree on the same set of domains.
- Removes the local `Where(sd => sd.Services.Any())` in `ServicesGenerator`, which was the source of the inconsistency. Given the same input, the root interface, the root class and the domain classes are now always consistent.
- Adds `TestDomainWithoutAnyServices_ServicesTypeNotReferenced` to `ServicesGeneratorTest`. It generates code for a domain with zero services next to a normal `light` domain, asserts the `{Domain}Services` name does not appear anywhere in the output, and compiles the generated code together with app code. It fails without the fix with three dangling references to the undeclared type.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for https://netdaemon.xyz

[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
