### PR TITLE
Return null from RegistryCache.GetLabelById for unknown labels

### DIFF
--- a/src/HassModel/NetDaemon.HassModel.Tests/Registry/RegistryNavigationTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Registry/RegistryNavigationTest.cs
@@ -152,6 +152,40 @@ public class RegistryNavigationTest
     }
 
     [Fact]
+    public async Task TestUnknownLabelIsIgnored()
+    {
+        // Setup: the label registry can lag behind the entity/area registries because each one is
+        // reloaded independently, so references to labels that are not (yet) known must not throw
+        SetupCommandResult("config/entity_registry/list",
+            [
+                new HassEntity { EntityId = "light.babyroom_nightlight", AreaId = "baby_room", Labels = ["stay_on", "unknown_label"] },
+            ]);
+        SetupCommandResult("config/device_registry/list", Array.Empty<HassDevice>());
+        SetupCommandResult("config/area_registry/list",
+            [
+                new HassArea { Name = "Baby room", Id = "baby_room", Labels = ["unknown_label"] },
+            ]);
+        SetupCommandResult("config/floor_registry/list", Array.Empty<HassFloor>());
+        SetupCommandResult("config/label_registry/list",
+            [
+                new HassLabel { Id = "stay_on", Name = "Stay On" },
+            ]);
+
+        // Act:
+        var registry = await InitializeCacheAndBuildRegistry();
+
+        // Assert:
+        registry.GetLabel("unknown_label").Should().BeNull();
+
+        registry.GetEntityRegistration("light.babyroom_nightlight")!.Labels.Should().BeEquivalentTo(
+        [
+            new { Name = "Stay On" },
+        ]);
+
+        registry.GetArea("baby_room")!.Labels.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task TestConversationOptions()
     {
         // Setup:

--- a/src/HassModel/NetDaemon.HassModel.Tests/Registry/RegistryNavigationTest.cs
+++ b/src/HassModel/NetDaemon.HassModel.Tests/Registry/RegistryNavigationTest.cs
@@ -186,6 +186,19 @@ public class RegistryNavigationTest
     }
 
     [Fact]
+    public async Task TestNullLabelIdReturnsNull()
+    {
+        // Setup:
+        InitializeDataModel();
+
+        // Act:
+        var registry = await InitializeCacheAndBuildRegistry();
+
+        // Assert:
+        registry.GetLabel(null).Should().BeNull();
+    }
+
+    [Fact]
     public async Task TestConversationOptions()
     {
         // Setup:

--- a/src/HassModel/NetDaemon.HassModel/Internal/RegistryCache.cs
+++ b/src/HassModel/NetDaemon.HassModel/Internal/RegistryCache.cs
@@ -125,7 +125,7 @@ internal class RegistryCache(IHomeAssistantRunner hassRunner, ILogger<RegistryCa
     public HassDevice? GetDeviceById(string? deviceId) => deviceId is null ? null : _devicesById.GetValueOrDefault(deviceId);
     public HassArea? GetAreaById(string? areaId) => areaId is null ? null : _areasById.GetValueOrDefault(areaId);
     public HassFloor? GetFloorById(string? floorId) => floorId is null ? null : _floorsById.GetValueOrDefault(floorId);
-    public HassLabel? GetLabelById(string? labelId) => labelId is null ? null : _labelsById[labelId];
+    public HassLabel? GetLabelById(string? labelId) => labelId is null ? null : _labelsById.GetValueOrDefault(labelId);
 
 
     public IEnumerable<HassEntity> GetEntitiesForArea(string? areaId) => _entitiesByAreaId[areaId];


### PR DESCRIPTION
## Proposed change

`RegistryCache.GetLabelById` used the dictionary indexer, so looking up a label id that is not in the label cache threw a `KeyNotFoundException`. Every sibling lookup (`GetHassEntityById`, `GetDeviceById`, `GetAreaById`, `GetFloorById`) already returns `null` for unknown ids, and `HassObjectMapper` filters those nulls out with `OfType<Label>()` when it maps the `Labels` collections of entities, devices and areas.

Each registry (entities, devices, areas, floors, labels) is reloaded independently and each has its own 5-minute throttle on its `*_registry_updated` event. This means the entity or area registry can reference a label the label registry has not loaded yet, for example right after a label is created and assigned in the Home Assistant UI. Any app that then touched `IHaContext.Registry`, `entity.Registration`, or navigated to an `Area`/`Device` threw instead of seeing the entity without that label.

This PR:

- Changes `GetLabelById` to use `GetValueOrDefault`, in line with the other lookups. An unknown label is now simply omitted from the mapped `Labels` lists, and `IHaRegistry.GetLabel` returns `null` for it.
- Adds `TestUnknownLabelIsIgnored` to `RegistryNavigationTest`. An entity and an area reference a label id that is not in the label registry; the test asserts `GetLabel` returns `null`, the entity registration keeps only the known label, and the area has no labels. Without the fix it fails with `KeyNotFoundException: The given key 'unknown_label' was not present in the dictionary.`

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code compiles without warnings (code quality check)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration are added/changed:

- [ ] Documentation added/updated for https://netdaemon.xyz

[Docs repository]: https://github.com/net-daemon/docs
[Developer documentation]: https://netdaemon.xyz/docs/developer/
